### PR TITLE
Removed json gem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gemspec
 
 gem 'mocha', :require => false
 gem 'rake', '< 11'
+gem 'json', :platform => :ruby_18

--- a/spdx-licenses.gemspec
+++ b/spdx-licenses.gemspec
@@ -14,6 +14,4 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.files = `git ls-files`.split("\n") - Dir[".*", "Gem*", "*.gemspec"]
-
-  s.add_dependency 'json'
 end


### PR DESCRIPTION
Not needed since ruby 1.9+ as it's including in the standard library

Similar pr sent to rails recently: https://github.com/rails/rails/pull/23453