### PR TITLE
Update licenses data to version 3.11

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -1,71 +1,35 @@
 {
-  "licenseListVersion": "3.1",
+  "licenseListVersion": "3.11-54-g1d17200",
   "licenses": [
     {
       "reference": "./0BSD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/0BSD.json",
-      "referenceNumber": "1",
+      "referenceNumber": "246",
       "name": "BSD Zero Clause License",
       "licenseId": "0BSD",
       "seeAlso": [
         "http://landley.net/toybox/license.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./AAL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AAL.json",
-      "referenceNumber": "2",
+      "referenceNumber": "59",
       "name": "Attribution Assurance License",
       "licenseId": "AAL",
       "seeAlso": [
-        "http://www.opensource.org/licenses/attribution"
+        "https://opensource.org/licenses/attribution"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./Abstyles.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
-      "referenceNumber": "3",
-      "name": "Abstyles License",
-      "licenseId": "Abstyles",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Abstyles"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Adobe-2006.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
-      "referenceNumber": "4",
-      "name": "Adobe Systems Incorporated Source Code License Agreement",
-      "licenseId": "Adobe-2006",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Adobe-Glyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
-      "referenceNumber": "5",
-      "name": "Adobe Glyph List License",
-      "licenseId": "Adobe-Glyph",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./ADSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ADSL.json",
-      "referenceNumber": "6",
+      "referenceNumber": "224",
       "name": "Amazon Digital Services License",
       "licenseId": "ADSL",
       "seeAlso": [
@@ -78,7 +42,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.1.json",
-      "referenceNumber": "7",
+      "referenceNumber": "143",
       "name": "Academic Free License v1.1",
       "licenseId": "AFL-1.1",
       "seeAlso": [
@@ -92,7 +56,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-1.2.json",
-      "referenceNumber": "8",
+      "referenceNumber": "247",
       "name": "Academic Free License v1.2",
       "licenseId": "AFL-1.2",
       "seeAlso": [
@@ -106,11 +70,10 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.0.json",
-      "referenceNumber": "9",
+      "referenceNumber": "360",
       "name": "Academic Free License v2.0",
       "licenseId": "AFL-2.0",
       "seeAlso": [
-        "http://opensource.linux-mirror.org/licenses/afl-2.0.txt",
         "http://wayback.archive.org/web/20060924134533/http://www.opensource.org/licenses/afl-2.0.txt"
       ],
       "isOsiApproved": true
@@ -120,7 +83,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-2.1.json",
-      "referenceNumber": "10",
+      "referenceNumber": "261",
       "name": "Academic Free License v2.1",
       "licenseId": "AFL-2.1",
       "seeAlso": [
@@ -133,24 +96,25 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AFL-3.0.json",
-      "referenceNumber": "11",
+      "referenceNumber": "380",
       "name": "Academic Free License v3.0",
       "licenseId": "AFL-3.0",
       "seeAlso": [
         "http://www.rosenlaw.com/AFL3.0.htm",
-        "http://www.opensource.org/licenses/afl-3.0"
+        "https://opensource.org/licenses/afl-3.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Afmparse.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
-      "referenceNumber": "12",
-      "name": "Afmparse License",
-      "licenseId": "Afmparse",
+      "reference": "./AGPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
+      "referenceNumber": "175",
+      "name": "Affero General Public License v1.0",
+      "licenseId": "AGPL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Afmparse"
+        "http://www.affero.org/oagpl.html"
       ],
       "isOsiApproved": false
     },
@@ -158,7 +122,7 @@
       "reference": "./AGPL-1.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-only.json",
-      "referenceNumber": "13",
+      "referenceNumber": "70",
       "name": "Affero General Public License v1.0 only",
       "licenseId": "AGPL-1.0-only",
       "seeAlso": [
@@ -170,7 +134,7 @@
       "reference": "./AGPL-1.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AGPL-1.0-or-later.json",
-      "referenceNumber": "14",
+      "referenceNumber": "170",
       "name": "Affero General Public License v1.0 or later",
       "licenseId": "AGPL-1.0-or-later",
       "seeAlso": [
@@ -179,16 +143,30 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./AGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
+      "referenceNumber": "146",
+      "name": "GNU Affero General Public License v3.0",
+      "licenseId": "AGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./AGPL-3.0-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-only.json",
-      "referenceNumber": "15",
+      "referenceNumber": "309",
       "name": "GNU Affero General Public License v3.0 only",
       "licenseId": "AGPL-3.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -197,32 +175,20 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/AGPL-3.0-or-later.json",
-      "referenceNumber": "16",
+      "referenceNumber": "159",
       "name": "GNU Affero General Public License v3.0 or later",
       "licenseId": "AGPL-3.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://www.gnu.org/licenses/agpl.txt",
+        "https://opensource.org/licenses/AGPL-3.0"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./Aladdin.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
-      "referenceNumber": "17",
-      "name": "Aladdin Free Public License",
-      "licenseId": "Aladdin",
-      "seeAlso": [
-        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./AMDPLPA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMDPLPA.json",
-      "referenceNumber": "18",
+      "referenceNumber": "133",
       "name": "AMD's plpa_map.c License",
       "licenseId": "AMDPLPA",
       "seeAlso": [
@@ -234,7 +200,7 @@
       "reference": "./AML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AML.json",
-      "referenceNumber": "19",
+      "referenceNumber": "156",
       "name": "Apple MIT License",
       "licenseId": "AML",
       "seeAlso": [
@@ -246,7 +212,7 @@
       "reference": "./AMPAS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/AMPAS.json",
-      "referenceNumber": "20",
+      "referenceNumber": "137",
       "name": "Academy of Motion Picture Arts and Sciences BSD",
       "licenseId": "AMPAS",
       "seeAlso": [
@@ -258,7 +224,7 @@
       "reference": "./ANTLR-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ANTLR-PD.json",
-      "referenceNumber": "21",
+      "referenceNumber": "41",
       "name": "ANTLR Software Rights Notice",
       "licenseId": "ANTLR-PD",
       "seeAlso": [
@@ -267,51 +233,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Apache-1.0.html",
+      "reference": "./ANTLR-PD-fallback.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
-      "referenceNumber": "22",
-      "name": "Apache License 1.0",
-      "licenseId": "Apache-1.0",
+      "detailsUrl": "http://spdx.org/licenses/ANTLR-PD-fallback.json",
+      "referenceNumber": "154",
+      "name": "ANTLR Software Rights Notice with license fallback",
+      "licenseId": "ANTLR-PD-fallback",
       "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-1.0"
+        "http://www.antlr2.org/license.html"
       ],
       "isOsiApproved": false
-    },
-    {
-      "reference": "./Apache-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
-      "referenceNumber": "23",
-      "name": "Apache License 1.1",
-      "licenseId": "Apache-1.1",
-      "seeAlso": [
-        "http://apache.org/licenses/LICENSE-1.1",
-        "http://opensource.org/licenses/Apache-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Apache-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
-      "referenceNumber": "24",
-      "name": "Apache License 2.0",
-      "licenseId": "Apache-2.0",
-      "seeAlso": [
-        "http://www.apache.org/licenses/LICENSE-2.0",
-        "http://www.opensource.org/licenses/Apache-2.0"
-      ],
-      "isOsiApproved": true
     },
     {
       "reference": "./APAFML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APAFML.json",
-      "referenceNumber": "25",
+      "referenceNumber": "256",
       "name": "Adobe Postscript AFM License",
       "licenseId": "APAFML",
       "seeAlso": [
@@ -323,11 +260,11 @@
       "reference": "./APL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APL-1.0.json",
-      "referenceNumber": "26",
+      "referenceNumber": "286",
       "name": "Adaptive Public License 1.0",
       "licenseId": "APL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/APL-1.0"
+        "https://opensource.org/licenses/APL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -335,7 +272,7 @@
       "reference": "./APSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.0.json",
-      "referenceNumber": "27",
+      "referenceNumber": "443",
       "name": "Apple Public Source License 1.0",
       "licenseId": "APSL-1.0",
       "seeAlso": [
@@ -347,7 +284,7 @@
       "reference": "./APSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.1.json",
-      "referenceNumber": "28",
+      "referenceNumber": "451",
       "name": "Apple Public Source License 1.1",
       "licenseId": "APSL-1.1",
       "seeAlso": [
@@ -359,7 +296,7 @@
       "reference": "./APSL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/APSL-1.2.json",
-      "referenceNumber": "29",
+      "referenceNumber": "207",
       "name": "Apple Public Source License 1.2",
       "licenseId": "APSL-1.2",
       "seeAlso": [
@@ -372,7 +309,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/APSL-2.0.json",
-      "referenceNumber": "30",
+      "referenceNumber": "447",
       "name": "Apple Public Source License 2.0",
       "licenseId": "APSL-2.0",
       "seeAlso": [
@@ -381,14 +318,115 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Artistic-1.0-cl8.html",
+      "reference": "./Abstyles.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
-      "referenceNumber": "31",
-      "name": "Artistic License 1.0 w/clause 8",
-      "licenseId": "Artistic-1.0-cl8",
+      "detailsUrl": "http://spdx.org/licenses/Abstyles.json",
+      "referenceNumber": "81",
+      "name": "Abstyles License",
+      "licenseId": "Abstyles",
       "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
+        "https://fedoraproject.org/wiki/Licensing/Abstyles"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Adobe-2006.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Adobe-2006.json",
+      "referenceNumber": "326",
+      "name": "Adobe Systems Incorporated Source Code License Agreement",
+      "licenseId": "Adobe-2006",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/AdobeLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Adobe-Glyph.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Adobe-Glyph.json",
+      "referenceNumber": "365",
+      "name": "Adobe Glyph List License",
+      "licenseId": "Adobe-Glyph",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MIT#AdobeGlyph"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Afmparse.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Afmparse.json",
+      "referenceNumber": "349",
+      "name": "Afmparse License",
+      "licenseId": "Afmparse",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Afmparse"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Aladdin.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Aladdin.json",
+      "referenceNumber": "358",
+      "name": "Aladdin Free Public License",
+      "licenseId": "Aladdin",
+      "seeAlso": [
+        "http://pages.cs.wisc.edu/~ghost/doc/AFPL/6.01/Public.htm"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Apache-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-1.0.json",
+      "referenceNumber": "144",
+      "name": "Apache License 1.0",
+      "licenseId": "Apache-1.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Apache-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-1.1.json",
+      "referenceNumber": "282",
+      "name": "Apache License 1.1",
+      "licenseId": "Apache-1.1",
+      "seeAlso": [
+        "http://apache.org/licenses/LICENSE-1.1",
+        "https://opensource.org/licenses/Apache-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Apache-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Apache-2.0.json",
+      "referenceNumber": "386",
+      "name": "Apache License 2.0",
+      "licenseId": "Apache-2.0",
+      "seeAlso": [
+        "http://www.apache.org/licenses/LICENSE-2.0",
+        "https://opensource.org/licenses/Apache-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Artistic-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
+      "referenceNumber": "281",
+      "name": "Artistic License 1.0",
+      "licenseId": "Artistic-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
@@ -396,7 +434,7 @@
       "reference": "./Artistic-1.0-Perl.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-Perl.json",
-      "referenceNumber": "32",
+      "referenceNumber": "319",
       "name": "Artistic License 1.0 (Perl)",
       "licenseId": "Artistic-1.0-Perl",
       "seeAlso": [
@@ -405,14 +443,14 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./Artistic-1.0.html",
+      "reference": "./Artistic-1.0-cl8.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0.json",
-      "referenceNumber": "33",
-      "name": "Artistic License 1.0",
-      "licenseId": "Artistic-1.0",
+      "detailsUrl": "http://spdx.org/licenses/Artistic-1.0-cl8.json",
+      "referenceNumber": "237",
+      "name": "Artistic License 1.0 w/clause 8",
+      "licenseId": "Artistic-1.0-cl8",
       "seeAlso": [
-        "http://opensource.org/licenses/Artistic-1.0"
+        "https://opensource.org/licenses/Artistic-1.0"
       ],
       "isOsiApproved": true
     },
@@ -421,107 +459,46 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Artistic-2.0.json",
-      "referenceNumber": "34",
+      "referenceNumber": "84",
       "name": "Artistic License 2.0",
       "licenseId": "Artistic-2.0",
       "seeAlso": [
         "http://www.perlfoundation.org/artistic_license_2_0",
-        "http://www.opensource.org/licenses/artistic-license-2.0"
+        "https://www.perlfoundation.org/artistic-license-20.html",
+        "https://opensource.org/licenses/artistic-license-2.0"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./Bahyph.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
-      "referenceNumber": "35",
-      "name": "Bahyph License",
-      "licenseId": "Bahyph",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Bahyph"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Barr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Barr.json",
-      "referenceNumber": "36",
-      "name": "Barr License",
-      "licenseId": "Barr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Barr"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Beerware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Beerware.json",
-      "referenceNumber": "37",
-      "name": "Beerware License",
-      "licenseId": "Beerware",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Beerware",
-        "https://people.freebsd.org/~phk/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BitTorrent-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
-      "referenceNumber": "38",
-      "name": "BitTorrent Open Source License v1.0",
-      "licenseId": "BitTorrent-1.0",
-      "seeAlso": [
-        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BitTorrent-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
-      "referenceNumber": "39",
-      "name": "BitTorrent Open Source License v1.1",
-      "licenseId": "BitTorrent-1.1",
-      "seeAlso": [
-        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Borceux.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Borceux.json",
-      "referenceNumber": "40",
-      "name": "Borceux license",
-      "licenseId": "Borceux",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Borceux"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./BSD-1-Clause.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-1-Clause.json",
-      "referenceNumber": "41",
+      "referenceNumber": "408",
       "name": "BSD 1-Clause License",
       "licenseId": "BSD-1-Clause",
       "seeAlso": [
         "https://svnweb.freebsd.org/base/head/include/ifaddrs.h?revision=326823"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./BSD-2-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
+      "referenceNumber": "323",
+      "name": "BSD 2-Clause \"Simplified\" License",
+      "licenseId": "BSD-2-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-2-Clause"
+      ],
+      "isOsiApproved": true
     },
     {
       "reference": "./BSD-2-Clause-FreeBSD.html",
-      "isDeprecatedLicenseId": false,
+      "isDeprecatedLicenseId": true,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-FreeBSD.json",
-      "referenceNumber": "42",
+      "referenceNumber": "290",
       "name": "BSD 2-Clause FreeBSD License",
       "licenseId": "BSD-2-Clause-FreeBSD",
       "seeAlso": [
@@ -531,9 +508,9 @@
     },
     {
       "reference": "./BSD-2-Clause-NetBSD.html",
-      "isDeprecatedLicenseId": false,
+      "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-NetBSD.json",
-      "referenceNumber": "43",
+      "referenceNumber": "188",
       "name": "BSD 2-Clause NetBSD License",
       "licenseId": "BSD-2-Clause-NetBSD",
       "seeAlso": [
@@ -545,7 +522,7 @@
       "reference": "./BSD-2-Clause-Patent.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Patent.json",
-      "referenceNumber": "44",
+      "referenceNumber": "383",
       "name": "BSD-2-Clause Plus Patent License",
       "licenseId": "BSD-2-Clause-Patent",
       "seeAlso": [
@@ -554,14 +531,29 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./BSD-2-Clause.html",
+      "reference": "./BSD-2-Clause-Views.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause.json",
-      "referenceNumber": "45",
-      "name": "BSD 2-Clause \"Simplified\" License",
-      "licenseId": "BSD-2-Clause",
+      "detailsUrl": "http://spdx.org/licenses/BSD-2-Clause-Views.json",
+      "referenceNumber": "287",
+      "name": "BSD 2-Clause with views sentence",
+      "licenseId": "BSD-2-Clause-Views",
       "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-2-Clause"
+        "http://www.freebsd.org/copyright/freebsd-license.html",
+        "https://people.freebsd.org/~ivoras/wine/patch-wine-nvidia.sh",
+        "https://github.com/protegeproject/protege/blob/master/license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-3-Clause.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
+      "referenceNumber": "212",
+      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+      "licenseId": "BSD-3-Clause",
+      "seeAlso": [
+        "https://opensource.org/licenses/BSD-3-Clause"
       ],
       "isOsiApproved": true
     },
@@ -569,7 +561,7 @@
       "reference": "./BSD-3-Clause-Attribution.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Attribution.json",
-      "referenceNumber": "46",
+      "referenceNumber": "34",
       "name": "BSD with attribution",
       "licenseId": "BSD-3-Clause-Attribution",
       "seeAlso": [
@@ -582,7 +574,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Clear.json",
-      "referenceNumber": "47",
+      "referenceNumber": "85",
       "name": "BSD 3-Clause Clear License",
       "licenseId": "BSD-3-Clause-Clear",
       "seeAlso": [
@@ -594,31 +586,19 @@
       "reference": "./BSD-3-Clause-LBNL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-LBNL.json",
-      "referenceNumber": "48",
+      "referenceNumber": "145",
       "name": "Lawrence Berkeley National Labs BSD variant license",
       "licenseId": "BSD-3-Clause-LBNL",
       "seeAlso": [
         "https://fedoraproject.org/wiki/Licensing/LBNLBSD"
       ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
-      "referenceNumber": "49",
-      "name": "BSD 3-Clause No Nuclear License 2014",
-      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
-      "seeAlso": [
-        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
-      ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./BSD-3-Clause-No-Nuclear-License.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License.json",
-      "referenceNumber": "50",
+      "referenceNumber": "444",
       "name": "BSD 3-Clause No Nuclear License",
       "licenseId": "BSD-3-Clause-No-Nuclear-License",
       "seeAlso": [
@@ -627,10 +607,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BSD-3-Clause-No-Nuclear-License-2014.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-License-2014.json",
+      "referenceNumber": "359",
+      "name": "BSD 3-Clause No Nuclear License 2014",
+      "licenseId": "BSD-3-Clause-No-Nuclear-License-2014",
+      "seeAlso": [
+        "https://java.net/projects/javaeetutorial/pages/BerkeleyLicense"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./BSD-3-Clause-No-Nuclear-Warranty.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-No-Nuclear-Warranty.json",
-      "referenceNumber": "51",
+      "referenceNumber": "117",
       "name": "BSD 3-Clause No Nuclear Warranty",
       "licenseId": "BSD-3-Clause-No-Nuclear-Warranty",
       "seeAlso": [
@@ -639,27 +631,15 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./BSD-3-Clause.html",
+      "reference": "./BSD-3-Clause-Open-MPI.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause.json",
-      "referenceNumber": "52",
-      "name": "BSD 3-Clause \"New\" or \"Revised\" License",
-      "licenseId": "BSD-3-Clause",
+      "detailsUrl": "http://spdx.org/licenses/BSD-3-Clause-Open-MPI.json",
+      "referenceNumber": "220",
+      "name": "BSD 3-Clause Open MPI variant",
+      "licenseId": "BSD-3-Clause-Open-MPI",
       "seeAlso": [
-        "http://www.opensource.org/licenses/BSD-3-Clause"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./BSD-4-Clause-UC.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
-      "referenceNumber": "53",
-      "name": "BSD-4-Clause (University of California-Specific)",
-      "licenseId": "BSD-4-Clause-UC",
-      "seeAlso": [
-        "http://www.freebsd.org/copyright/license.html"
+        "https://www.open-mpi.org/community/license.php",
+        "http://www.netlib.org/lapack/LICENSE.txt"
       ],
       "isOsiApproved": false
     },
@@ -668,7 +648,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause.json",
-      "referenceNumber": "54",
+      "referenceNumber": "67",
       "name": "BSD 4-Clause \"Original\" or \"Old\" License",
       "licenseId": "BSD-4-Clause",
       "seeAlso": [
@@ -677,10 +657,34 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./BSD-4-Clause-Shortened.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-Shortened.json",
+      "referenceNumber": "307",
+      "name": "BSD 4 Clause Shortened",
+      "licenseId": "BSD-4-Clause-Shortened",
+      "seeAlso": [
+        "https://metadata.ftp-master.debian.org/changelogs//main/a/arpwatch/arpwatch_2.1a15-7_copyright"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BSD-4-Clause-UC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BSD-4-Clause-UC.json",
+      "referenceNumber": "393",
+      "name": "BSD-4-Clause (University of California-Specific)",
+      "licenseId": "BSD-4-Clause-UC",
+      "seeAlso": [
+        "http://www.freebsd.org/copyright/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./BSD-Protection.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Protection.json",
-      "referenceNumber": "55",
+      "referenceNumber": "419",
       "name": "BSD Protection License",
       "licenseId": "BSD-Protection",
       "seeAlso": [
@@ -692,7 +696,7 @@
       "reference": "./BSD-Source-Code.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/BSD-Source-Code.json",
-      "referenceNumber": "56",
+      "referenceNumber": "169",
       "name": "BSD Source Code Attribution",
       "licenseId": "BSD-Source-Code",
       "seeAlso": [
@@ -705,60 +709,148 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/BSL-1.0.json",
-      "referenceNumber": "57",
+      "referenceNumber": "305",
       "name": "Boost Software License 1.0",
       "licenseId": "BSL-1.0",
       "seeAlso": [
         "http://www.boost.org/LICENSE_1_0.txt",
-        "http://www.opensource.org/licenses/BSL-1.0"
+        "https://opensource.org/licenses/BSL-1.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./bzip2-1.0.5.html",
+      "reference": "./BUSL-1.1.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
-      "referenceNumber": "58",
-      "name": "bzip2 and libbzip2 License v1.0.5",
-      "licenseId": "bzip2-1.0.5",
+      "detailsUrl": "http://spdx.org/licenses/BUSL-1.1.json",
+      "referenceNumber": "37",
+      "name": "Business Source License 1.1",
+      "licenseId": "BUSL-1.1",
       "seeAlso": [
-        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+        "https://mariadb.com/bsl11/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./bzip2-1.0.6.html",
+      "reference": "./Bahyph.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
-      "referenceNumber": "59",
-      "name": "bzip2 and libbzip2 License v1.0.6",
-      "licenseId": "bzip2-1.0.6",
+      "detailsUrl": "http://spdx.org/licenses/Bahyph.json",
+      "referenceNumber": "149",
+      "name": "Bahyph License",
+      "licenseId": "Bahyph",
       "seeAlso": [
-        "https://github.com/asimonov-im/bzip2/blob/master/LICENSE"
+        "https://fedoraproject.org/wiki/Licensing/Bahyph"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Caldera.html",
+      "reference": "./Barr.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Caldera.json",
-      "referenceNumber": "60",
-      "name": "Caldera License",
-      "licenseId": "Caldera",
+      "detailsUrl": "http://spdx.org/licenses/Barr.json",
+      "referenceNumber": "126",
+      "name": "Barr License",
+      "licenseId": "Barr",
       "seeAlso": [
-        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
+        "https://fedoraproject.org/wiki/Licensing/Barr"
       ],
       "isOsiApproved": false
+    },
+    {
+      "reference": "./Beerware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Beerware.json",
+      "referenceNumber": "259",
+      "name": "Beerware License",
+      "licenseId": "Beerware",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Beerware",
+        "https://people.freebsd.org/~phk/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BitTorrent-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.0.json",
+      "referenceNumber": "214",
+      "name": "BitTorrent Open Source License v1.0",
+      "licenseId": "BitTorrent-1.0",
+      "seeAlso": [
+        "http://sources.gentoo.org/cgi-bin/viewvc.cgi/gentoo-x86/licenses/BitTorrent?r1=1.1&r2=1.1.1.1&diff_format=s"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BitTorrent-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/BitTorrent-1.1.json",
+      "referenceNumber": "192",
+      "name": "BitTorrent Open Source License v1.1",
+      "licenseId": "BitTorrent-1.1",
+      "seeAlso": [
+        "http://directory.fsf.org/wiki/License:BitTorrentOSL1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./BlueOak-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/BlueOak-1.0.0.json",
+      "referenceNumber": "217",
+      "name": "Blue Oak Model License 1.0.0",
+      "licenseId": "BlueOak-1.0.0",
+      "seeAlso": [
+        "https://blueoakcouncil.org/license/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Borceux.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Borceux.json",
+      "referenceNumber": "318",
+      "name": "Borceux license",
+      "licenseId": "Borceux",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Borceux"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CAL-1.0.json",
+      "referenceNumber": "55",
+      "name": "Cryptographic Autonomy License 1.0",
+      "licenseId": "CAL-1.0",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CAL-1.0-Combined-Work-Exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CAL-1.0-Combined-Work-Exception.json",
+      "referenceNumber": "76",
+      "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+      "licenseId": "CAL-1.0-Combined-Work-Exception",
+      "seeAlso": [
+        "http://cryptographicautonomylicense.com/license-text.html",
+        "https://opensource.org/licenses/CAL-1.0"
+      ],
+      "isOsiApproved": true
     },
     {
       "reference": "./CATOSL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CATOSL-1.1.json",
-      "referenceNumber": "61",
+      "referenceNumber": "241",
       "name": "Computer Associates Trusted Open Source License 1.1",
       "licenseId": "CATOSL-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/CATOSL-1.1"
+        "https://opensource.org/licenses/CATOSL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -766,11 +858,11 @@
       "reference": "./CC-BY-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-1.0.json",
-      "referenceNumber": "62",
+      "referenceNumber": "16",
       "name": "Creative Commons Attribution 1.0 Generic",
       "licenseId": "CC-BY-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/1.0/legalcode"
+        "https://creativecommons.org/licenses/by/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -778,11 +870,11 @@
       "reference": "./CC-BY-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.0.json",
-      "referenceNumber": "63",
+      "referenceNumber": "57",
       "name": "Creative Commons Attribution 2.0 Generic",
       "licenseId": "CC-BY-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.0/legalcode"
+        "https://creativecommons.org/licenses/by/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -790,11 +882,11 @@
       "reference": "./CC-BY-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-2.5.json",
-      "referenceNumber": "64",
+      "referenceNumber": "191",
       "name": "Creative Commons Attribution 2.5 Generic",
       "licenseId": "CC-BY-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/2.5/legalcode"
+        "https://creativecommons.org/licenses/by/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -802,11 +894,35 @@
       "reference": "./CC-BY-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0.json",
-      "referenceNumber": "65",
+      "referenceNumber": "361",
       "name": "Creative Commons Attribution 3.0 Unported",
       "licenseId": "CC-BY-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/3.0/legalcode"
+        "https://creativecommons.org/licenses/by/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0-AT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0-AT.json",
+      "referenceNumber": "330",
+      "name": "Creative Commons Attribution 3.0 Austria",
+      "licenseId": "CC-BY-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/at/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-3.0-US.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-3.0-US.json",
+      "referenceNumber": "347",
+      "name": "Creative Commons Attribution 3.0 United States",
+      "licenseId": "CC-BY-3.0-US",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by/3.0/us/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -815,11 +931,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-4.0.json",
-      "referenceNumber": "66",
+      "referenceNumber": "225",
       "name": "Creative Commons Attribution 4.0 International",
       "licenseId": "CC-BY-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by/4.0/legalcode"
+        "https://creativecommons.org/licenses/by/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -827,11 +943,11 @@
       "reference": "./CC-BY-NC-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-1.0.json",
-      "referenceNumber": "67",
+      "referenceNumber": "238",
       "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
       "licenseId": "CC-BY-NC-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -839,11 +955,11 @@
       "reference": "./CC-BY-NC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.0.json",
-      "referenceNumber": "68",
+      "referenceNumber": "342",
       "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
       "licenseId": "CC-BY-NC-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -851,11 +967,11 @@
       "reference": "./CC-BY-NC-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-2.5.json",
-      "referenceNumber": "69",
+      "referenceNumber": "417",
       "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
       "licenseId": "CC-BY-NC-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -863,11 +979,11 @@
       "reference": "./CC-BY-NC-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-3.0.json",
-      "referenceNumber": "70",
+      "referenceNumber": "352",
       "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
       "licenseId": "CC-BY-NC-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -875,11 +991,11 @@
       "reference": "./CC-BY-NC-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-4.0.json",
-      "referenceNumber": "71",
+      "referenceNumber": "280",
       "name": "Creative Commons Attribution Non Commercial 4.0 International",
       "licenseId": "CC-BY-NC-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -887,11 +1003,11 @@
       "reference": "./CC-BY-NC-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-1.0.json",
-      "referenceNumber": "72",
+      "referenceNumber": "99",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-NC-ND-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd-nc/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -899,11 +1015,11 @@
       "reference": "./CC-BY-NC-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.0.json",
-      "referenceNumber": "73",
+      "referenceNumber": "136",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-NC-ND-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -911,11 +1027,11 @@
       "reference": "./CC-BY-NC-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-2.5.json",
-      "referenceNumber": "74",
+      "referenceNumber": "23",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-NC-ND-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -923,11 +1039,23 @@
       "reference": "./CC-BY-NC-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0.json",
-      "referenceNumber": "75",
+      "referenceNumber": "36",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-NC-ND-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-NC-ND-3.0-IGO.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-3.0-IGO.json",
+      "referenceNumber": "366",
+      "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+      "licenseId": "CC-BY-NC-ND-3.0-IGO",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-nc-nd/3.0/igo/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -935,11 +1063,11 @@
       "reference": "./CC-BY-NC-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-ND-4.0.json",
-      "referenceNumber": "76",
+      "referenceNumber": "172",
       "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
       "licenseId": "CC-BY-NC-ND-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-nd/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -947,11 +1075,11 @@
       "reference": "./CC-BY-NC-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-1.0.json",
-      "referenceNumber": "77",
+      "referenceNumber": "118",
       "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
       "licenseId": "CC-BY-NC-SA-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -959,11 +1087,11 @@
       "reference": "./CC-BY-NC-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.0.json",
-      "referenceNumber": "78",
+      "referenceNumber": "431",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
       "licenseId": "CC-BY-NC-SA-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/2.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -971,11 +1099,11 @@
       "reference": "./CC-BY-NC-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-2.5.json",
-      "referenceNumber": "79",
+      "referenceNumber": "221",
       "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
       "licenseId": "CC-BY-NC-SA-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -983,11 +1111,11 @@
       "reference": "./CC-BY-NC-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-3.0.json",
-      "referenceNumber": "80",
+      "referenceNumber": "379",
       "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
       "licenseId": "CC-BY-NC-SA-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -995,11 +1123,11 @@
       "reference": "./CC-BY-NC-SA-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-NC-SA-4.0.json",
-      "referenceNumber": "81",
+      "referenceNumber": "348",
       "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
       "licenseId": "CC-BY-NC-SA-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nc-sa/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1007,11 +1135,11 @@
       "reference": "./CC-BY-ND-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-1.0.json",
-      "referenceNumber": "82",
+      "referenceNumber": "91",
       "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
       "licenseId": "CC-BY-ND-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1019,7 +1147,7 @@
       "reference": "./CC-BY-ND-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.0.json",
-      "referenceNumber": "83",
+      "referenceNumber": "50",
       "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
       "licenseId": "CC-BY-ND-2.0",
       "seeAlso": [
@@ -1031,11 +1159,11 @@
       "reference": "./CC-BY-ND-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-2.5.json",
-      "referenceNumber": "84",
+      "referenceNumber": "20",
       "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
       "licenseId": "CC-BY-ND-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-nd/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1043,11 +1171,11 @@
       "reference": "./CC-BY-ND-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-3.0.json",
-      "referenceNumber": "85",
+      "referenceNumber": "295",
       "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
       "licenseId": "CC-BY-ND-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/3.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1055,11 +1183,11 @@
       "reference": "./CC-BY-ND-4.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-ND-4.0.json",
-      "referenceNumber": "86",
+      "referenceNumber": "334",
       "name": "Creative Commons Attribution No Derivatives 4.0 International",
       "licenseId": "CC-BY-ND-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-nd/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-nd/4.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1067,11 +1195,11 @@
       "reference": "./CC-BY-SA-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-1.0.json",
-      "referenceNumber": "87",
+      "referenceNumber": "423",
       "name": "Creative Commons Attribution Share Alike 1.0 Generic",
       "licenseId": "CC-BY-SA-1.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/1.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1079,11 +1207,23 @@
       "reference": "./CC-BY-SA-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0.json",
-      "referenceNumber": "88",
+      "referenceNumber": "389",
       "name": "Creative Commons Attribution Share Alike 2.0 Generic",
       "licenseId": "CC-BY-SA-2.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/2.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-2.0-UK.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.0-UK.json",
+      "referenceNumber": "5",
+      "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+      "licenseId": "CC-BY-SA-2.0-UK",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/2.0/uk/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1091,11 +1231,11 @@
       "reference": "./CC-BY-SA-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-2.5.json",
-      "referenceNumber": "89",
+      "referenceNumber": "209",
       "name": "Creative Commons Attribution Share Alike 2.5 Generic",
       "licenseId": "CC-BY-SA-2.5",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/2.5/legalcode"
+        "https://creativecommons.org/licenses/by-sa/2.5/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1103,11 +1243,23 @@
       "reference": "./CC-BY-SA-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0.json",
-      "referenceNumber": "90",
+      "referenceNumber": "242",
       "name": "Creative Commons Attribution Share Alike 3.0 Unported",
       "licenseId": "CC-BY-SA-3.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/3.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/3.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-BY-SA-3.0-AT.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-3.0-AT.json",
+      "referenceNumber": "301",
+      "name": "Creative Commons Attribution-Share Alike 3.0 Austria",
+      "licenseId": "CC-BY-SA-3.0-AT",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/by-sa/3.0/at/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1116,11 +1268,23 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC-BY-SA-4.0.json",
-      "referenceNumber": "91",
+      "referenceNumber": "308",
       "name": "Creative Commons Attribution Share Alike 4.0 International",
       "licenseId": "CC-BY-SA-4.0",
       "seeAlso": [
-        "http://creativecommons.org/licenses/by-sa/4.0/legalcode"
+        "https://creativecommons.org/licenses/by-sa/4.0/legalcode"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CC-PDDC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CC-PDDC.json",
+      "referenceNumber": "90",
+      "name": "Creative Commons Public Domain Dedication and Certification",
+      "licenseId": "CC-PDDC",
+      "seeAlso": [
+        "https://creativecommons.org/licenses/publicdomain/"
       ],
       "isOsiApproved": false
     },
@@ -1129,11 +1293,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CC0-1.0.json",
-      "referenceNumber": "92",
+      "referenceNumber": "64",
       "name": "Creative Commons Zero v1.0 Universal",
       "licenseId": "CC0-1.0",
       "seeAlso": [
-        "http://creativecommons.org/publicdomain/zero/1.0/legalcode"
+        "https://creativecommons.org/publicdomain/zero/1.0/legalcode"
       ],
       "isOsiApproved": false
     },
@@ -1142,11 +1306,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.0.json",
-      "referenceNumber": "93",
+      "referenceNumber": "351",
       "name": "Common Development and Distribution License 1.0",
       "licenseId": "CDDL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/cddl1"
+        "https://opensource.org/licenses/cddl1"
       ],
       "isOsiApproved": true
     },
@@ -1154,7 +1318,7 @@
       "reference": "./CDDL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDDL-1.1.json",
-      "referenceNumber": "94",
+      "referenceNumber": "449",
       "name": "Common Development and Distribution License 1.1",
       "licenseId": "CDDL-1.1",
       "seeAlso": [
@@ -1167,7 +1331,7 @@
       "reference": "./CDLA-Permissive-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Permissive-1.0.json",
-      "referenceNumber": "95",
+      "referenceNumber": "106",
       "name": "Community Data License Agreement Permissive 1.0",
       "licenseId": "CDLA-Permissive-1.0",
       "seeAlso": [
@@ -1179,7 +1343,7 @@
       "reference": "./CDLA-Sharing-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CDLA-Sharing-1.0.json",
-      "referenceNumber": "96",
+      "referenceNumber": "181",
       "name": "Community Data License Agreement Sharing 1.0",
       "licenseId": "CDLA-Sharing-1.0",
       "seeAlso": [
@@ -1191,7 +1355,7 @@
       "reference": "./CECILL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.0.json",
-      "referenceNumber": "97",
+      "referenceNumber": "66",
       "name": "CeCILL Free Software License Agreement v1.0",
       "licenseId": "CECILL-1.0",
       "seeAlso": [
@@ -1203,7 +1367,7 @@
       "reference": "./CECILL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-1.1.json",
-      "referenceNumber": "98",
+      "referenceNumber": "161",
       "name": "CeCILL Free Software License Agreement v1.1",
       "licenseId": "CECILL-1.1",
       "seeAlso": [
@@ -1216,7 +1380,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.0.json",
-      "referenceNumber": "99",
+      "referenceNumber": "63",
       "name": "CeCILL Free Software License Agreement v2.0",
       "licenseId": "CECILL-2.0",
       "seeAlso": [
@@ -1228,7 +1392,7 @@
       "reference": "./CECILL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CECILL-2.1.json",
-      "referenceNumber": "100",
+      "referenceNumber": "174",
       "name": "CeCILL Free Software License Agreement v2.1",
       "licenseId": "CECILL-2.1",
       "seeAlso": [
@@ -1241,7 +1405,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-B.json",
-      "referenceNumber": "101",
+      "referenceNumber": "138",
       "name": "CeCILL-B Free Software License Agreement",
       "licenseId": "CECILL-B",
       "seeAlso": [
@@ -1254,11 +1418,169 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/CECILL-C.json",
-      "referenceNumber": "102",
+      "referenceNumber": "271",
       "name": "CeCILL-C Free Software License Agreement",
       "licenseId": "CECILL-C",
       "seeAlso": [
-        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html\n    "
+        "http://www.cecill.info/licences/Licence_CeCILL-C_V1-en.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.1.json",
+      "referenceNumber": "123",
+      "name": "CERN Open Hardware Licence v1.1",
+      "licenseId": "CERN-OHL-1.1",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-1.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-1.2.json",
+      "referenceNumber": "171",
+      "name": "CERN Open Hardware Licence v1.2",
+      "licenseId": "CERN-OHL-1.2",
+      "seeAlso": [
+        "https://www.ohwr.org/project/licenses/wikis/cern-ohl-v1.2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-P-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-P-2.0.json",
+      "referenceNumber": "266",
+      "name": "CERN Open Hardware Licence Version 2 - Permissive",
+      "licenseId": "CERN-OHL-P-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-S-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-S-2.0.json",
+      "referenceNumber": "44",
+      "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+      "licenseId": "CERN-OHL-S-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CERN-OHL-W-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CERN-OHL-W-2.0.json",
+      "referenceNumber": "276",
+      "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+      "licenseId": "CERN-OHL-W-2.0",
+      "seeAlso": [
+        "https://www.ohwr.org/project/cernohl/wikis/Documents/CERN-OHL-version-2"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Jython.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
+      "referenceNumber": "73",
+      "name": "CNRI Jython License",
+      "licenseId": "CNRI-Jython",
+      "seeAlso": [
+        "http://www.jython.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CNRI-Python.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
+      "referenceNumber": "95",
+      "name": "CNRI Python License",
+      "licenseId": "CNRI-Python",
+      "seeAlso": [
+        "https://opensource.org/licenses/CNRI-Python"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CNRI-Python-GPL-Compatible.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
+      "referenceNumber": "421",
+      "name": "CNRI Python Open Source GPL Compatible License Agreement",
+      "licenseId": "CNRI-Python-GPL-Compatible",
+      "seeAlso": [
+        "http://www.python.org/download/releases/1.6.1/download_win/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CPAL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
+      "referenceNumber": "294",
+      "name": "Common Public Attribution License 1.0",
+      "licenseId": "CPAL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPAL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
+      "referenceNumber": "243",
+      "name": "Common Public License 1.0",
+      "licenseId": "CPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./CPOL-1.02.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
+      "referenceNumber": "240",
+      "name": "Code Project Open License 1.02",
+      "licenseId": "CPOL-1.02",
+      "seeAlso": [
+        "http://www.codeproject.com/info/cpol10.aspx"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./CUA-OPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
+      "referenceNumber": "168",
+      "name": "CUA Office Public License v1.0",
+      "licenseId": "CUA-OPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/CUA-OPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Caldera.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Caldera.json",
+      "referenceNumber": "258",
+      "name": "Caldera License",
+      "licenseId": "Caldera",
+      "seeAlso": [
+        "http://www.lemis.com/grog/UNIX/ancient-source-all.pdf"
       ],
       "isOsiApproved": false
     },
@@ -1267,7 +1589,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ClArtistic.json",
-      "referenceNumber": "103",
+      "referenceNumber": "253",
       "name": "Clarified Artistic License",
       "licenseId": "ClArtistic",
       "seeAlso": [
@@ -1277,47 +1599,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CNRI-Jython.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Jython.json",
-      "referenceNumber": "104",
-      "name": "CNRI Jython License",
-      "licenseId": "CNRI-Jython",
-      "seeAlso": [
-        "http://www.jython.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CNRI-Python-GPL-Compatible.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python-GPL-Compatible.json",
-      "referenceNumber": "105",
-      "name": "CNRI Python Open Source GPL Compatible License Agreement",
-      "licenseId": "CNRI-Python-GPL-Compatible",
-      "seeAlso": [
-        "http://www.python.org/download/releases/1.6.1/download_win/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./CNRI-Python.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CNRI-Python.json",
-      "referenceNumber": "106",
-      "name": "CNRI Python License",
-      "licenseId": "CNRI-Python",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/CNRI-Python"
-      ],
-      "isOsiApproved": true
-    },
-    {
       "reference": "./Condor-1.1.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Condor-1.1.json",
-      "referenceNumber": "107",
+      "referenceNumber": "148",
       "name": "Condor Public License v1.1",
       "licenseId": "Condor-1.1",
       "seeAlso": [
@@ -1327,48 +1613,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CPAL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPAL-1.0.json",
-      "referenceNumber": "108",
-      "name": "Common Public Attribution License 1.0",
-      "licenseId": "CPAL-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/CPAL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/CPL-1.0.json",
-      "referenceNumber": "109",
-      "name": "Common Public License 1.0",
-      "licenseId": "CPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/CPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./CPOL-1.02.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CPOL-1.02.json",
-      "referenceNumber": "110",
-      "name": "Code Project Open License 1.02",
-      "licenseId": "CPOL-1.02",
-      "seeAlso": [
-        "http://www.codeproject.com/info/cpol10.aspx"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./Crossword.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Crossword.json",
-      "referenceNumber": "111",
+      "referenceNumber": "98",
       "name": "Crossword License",
       "licenseId": "Crossword",
       "seeAlso": [
@@ -1380,7 +1628,7 @@
       "reference": "./CrystalStacker.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/CrystalStacker.json",
-      "referenceNumber": "112",
+      "referenceNumber": "35",
       "name": "CrystalStacker License",
       "licenseId": "CrystalStacker",
       "seeAlso": [
@@ -1389,22 +1637,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./CUA-OPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/CUA-OPL-1.0.json",
-      "referenceNumber": "113",
-      "name": "CUA Office Public License v1.0",
-      "licenseId": "CUA-OPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/CUA-OPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
       "reference": "./Cube.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Cube.json",
-      "referenceNumber": "114",
+      "referenceNumber": "410",
       "name": "Cube License",
       "licenseId": "Cube",
       "seeAlso": [
@@ -1413,22 +1649,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./curl.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/curl.json",
-      "referenceNumber": "115",
-      "name": "curl License",
-      "licenseId": "curl",
-      "seeAlso": [
-        "https://github.com/bagder/curl/blob/master/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./D-FSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/D-FSL-1.0.json",
-      "referenceNumber": "116",
+      "referenceNumber": "381",
       "name": "Deutsche Freie Software Lizenz",
       "licenseId": "D-FSL-1.0",
       "seeAlso": [
@@ -1444,38 +1668,27 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./diffmark.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
-      "referenceNumber": "117",
-      "name": "diffmark license",
-      "licenseId": "diffmark",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/diffmark"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./DOC.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DOC.json",
-      "referenceNumber": "118",
+      "referenceNumber": "285",
       "name": "DOC License",
       "licenseId": "DOC",
       "seeAlso": [
-        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html"
+        "http://www.cs.wustl.edu/~schmidt/ACE-copying.html",
+        "https://www.dre.vanderbilt.edu/~schmidt/ACE-copying.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Dotseqn.html",
+      "reference": "./DRL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
-      "referenceNumber": "119",
-      "name": "Dotseqn License",
-      "licenseId": "Dotseqn",
+      "detailsUrl": "http://spdx.org/licenses/DRL-1.0.json",
+      "referenceNumber": "105",
+      "name": "Detection Rule License 1.0",
+      "licenseId": "DRL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
+        "https://github.com/Neo23x0/sigma/blob/master/LICENSE.Detection.Rules.md"
       ],
       "isOsiApproved": false
     },
@@ -1483,7 +1696,7 @@
       "reference": "./DSDP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/DSDP.json",
-      "referenceNumber": "120",
+      "referenceNumber": "274",
       "name": "DSDP License",
       "licenseId": "DSDP",
       "seeAlso": [
@@ -1492,14 +1705,14 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./dvipdfm.html",
+      "reference": "./Dotseqn.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
-      "referenceNumber": "121",
-      "name": "dvipdfm License",
-      "licenseId": "dvipdfm",
+      "detailsUrl": "http://spdx.org/licenses/Dotseqn.json",
+      "referenceNumber": "26",
+      "name": "Dotseqn License",
+      "licenseId": "Dotseqn",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+        "https://fedoraproject.org/wiki/Licensing/Dotseqn"
       ],
       "isOsiApproved": false
     },
@@ -1507,11 +1720,11 @@
       "reference": "./ECL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ECL-1.0.json",
-      "referenceNumber": "122",
+      "referenceNumber": "442",
       "name": "Educational Community License v1.0",
       "licenseId": "ECL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/ECL-1.0"
+        "https://opensource.org/licenses/ECL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1520,11 +1733,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ECL-2.0.json",
-      "referenceNumber": "123",
+      "referenceNumber": "8",
       "name": "Educational Community License v2.0",
       "licenseId": "ECL-2.0",
       "seeAlso": [
-        "http://opensource.org/licenses/ECL-2.0"
+        "https://opensource.org/licenses/ECL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -1532,12 +1745,12 @@
       "reference": "./EFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EFL-1.0.json",
-      "referenceNumber": "124",
+      "referenceNumber": "75",
       "name": "Eiffel Forum License v1.0",
       "licenseId": "EFL-1.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/forum.txt",
-        "http://opensource.org/licenses/EFL-1.0"
+        "https://opensource.org/licenses/EFL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1546,51 +1759,38 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EFL-2.0.json",
-      "referenceNumber": "125",
+      "referenceNumber": "7",
       "name": "Eiffel Forum License v2.0",
       "licenseId": "EFL-2.0",
       "seeAlso": [
         "http://www.eiffel-nice.org/license/eiffel-forum-license-2.html",
-        "http://opensource.org/licenses/EFL-2.0"
+        "https://opensource.org/licenses/EFL-2.0"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./eGenix.html",
+      "reference": "./EPICS.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
-      "referenceNumber": "126",
-      "name": "eGenix.com Public License 1.1.0",
-      "licenseId": "eGenix",
+      "detailsUrl": "http://spdx.org/licenses/EPICS.json",
+      "referenceNumber": "377",
+      "name": "EPICS Open License",
+      "licenseId": "EPICS",
       "seeAlso": [
-        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
-        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
+        "https://epics.anl.gov/license/open.php"
       ],
       "isOsiApproved": false
-    },
-    {
-      "reference": "./Entessa.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Entessa.json",
-      "referenceNumber": "127",
-      "name": "Entessa Public License v1.0",
-      "licenseId": "Entessa",
-      "seeAlso": [
-        "http://opensource.org/licenses/Entessa"
-      ],
-      "isOsiApproved": true
     },
     {
       "reference": "./EPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-1.0.json",
-      "referenceNumber": "128",
+      "referenceNumber": "291",
       "name": "Eclipse Public License 1.0",
       "licenseId": "EPL-1.0",
       "seeAlso": [
         "http://www.eclipse.org/legal/epl-v10.html",
-        "http://www.opensource.org/licenses/EPL-1.0"
+        "https://opensource.org/licenses/EPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -1599,7 +1799,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EPL-2.0.json",
-      "referenceNumber": "129",
+      "referenceNumber": "437",
       "name": "Eclipse Public License 2.0",
       "licenseId": "EPL-2.0",
       "seeAlso": [
@@ -1609,28 +1809,16 @@
       "isOsiApproved": true
     },
     {
-      "reference": "./ErlPL-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
-      "referenceNumber": "130",
-      "name": "Erlang Public License v1.1",
-      "licenseId": "ErlPL-1.1",
-      "seeAlso": [
-        "http://www.erlang.org/EPLICENSE"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./EUDatagrid.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUDatagrid.json",
-      "referenceNumber": "131",
+      "referenceNumber": "272",
       "name": "EU DataGrid Software License",
       "licenseId": "EUDatagrid",
       "seeAlso": [
         "http://eu-datagrid.web.cern.ch/eu-datagrid/license.html",
-        "http://www.opensource.org/licenses/EUDatagrid"
+        "https://opensource.org/licenses/EUDatagrid"
       ],
       "isOsiApproved": true
     },
@@ -1638,7 +1826,7 @@
       "reference": "./EUPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.0.json",
-      "referenceNumber": "132",
+      "referenceNumber": "100",
       "name": "European Union Public License 1.0",
       "licenseId": "EUPL-1.0",
       "seeAlso": [
@@ -1652,13 +1840,13 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.1.json",
-      "referenceNumber": "133",
+      "referenceNumber": "429",
       "name": "European Union Public License 1.1",
       "licenseId": "EUPL-1.1",
       "seeAlso": [
         "https://joinup.ec.europa.eu/software/page/eupl/licence-eupl",
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl1.1.-licence-en_0.pdf",
-        "http://www.opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/licenses/EUPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -1666,23 +1854,48 @@
       "reference": "./EUPL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/EUPL-1.2.json",
-      "referenceNumber": "134",
+      "referenceNumber": "283",
       "name": "European Union Public License 1.2",
       "licenseId": "EUPL-1.2",
       "seeAlso": [
         "https://joinup.ec.europa.eu/page/eupl-text-11-12",
         "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/eupl_v1.2_en.pdf",
+        "https://joinup.ec.europa.eu/sites/default/files/custom-page/attachment/2020-03/EUPL-1.2%20EN.txt",
         "https://joinup.ec.europa.eu/sites/default/files/inline-files/EUPL%20v1_2%20EN(1).txt",
         "http://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32017D0863",
-        "http://www.opensource.org/licenses/EUPL-1.1"
+        "https://opensource.org/licenses/EUPL-1.2"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./Entessa.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Entessa.json",
+      "referenceNumber": "406",
+      "name": "Entessa Public License v1.0",
+      "licenseId": "Entessa",
+      "seeAlso": [
+        "https://opensource.org/licenses/Entessa"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./ErlPL-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ErlPL-1.1.json",
+      "referenceNumber": "427",
+      "name": "Erlang Public License v1.1",
+      "licenseId": "ErlPL-1.1",
+      "seeAlso": [
+        "http://www.erlang.org/EPLICENSE"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./Eurosym.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Eurosym.json",
-      "referenceNumber": "135",
+      "referenceNumber": "173",
       "name": "Eurosym License",
       "licenseId": "Eurosym",
       "seeAlso": [
@@ -1691,52 +1904,15 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Fair.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Fair.json",
-      "referenceNumber": "136",
-      "name": "Fair License",
-      "licenseId": "Fair",
-      "seeAlso": [
-        "http://fairlicense.org/",
-        "http://www.opensource.org/licenses/Fair"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Frameworx-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
-      "referenceNumber": "137",
-      "name": "Frameworx Open License 1.0",
-      "licenseId": "Frameworx-1.0",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Frameworx-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./FreeImage.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
-      "referenceNumber": "138",
-      "name": "FreeImage Public License v1.0",
-      "licenseId": "FreeImage",
-      "seeAlso": [
-        "http://freeimage.sourceforge.net/freeimage-license.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./FSFAP.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FSFAP.json",
-      "referenceNumber": "139",
+      "referenceNumber": "413",
       "name": "FSF All Permissive License",
       "licenseId": "FSFAP",
       "seeAlso": [
-        "http://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
+        "https://www.gnu.org/prep/maintain/html_node/License-Notices-for-Other-Files.html"
       ],
       "isOsiApproved": false
     },
@@ -1744,7 +1920,7 @@
       "reference": "./FSFUL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFUL.json",
-      "referenceNumber": "140",
+      "referenceNumber": "3",
       "name": "FSF Unlimited License",
       "licenseId": "FSFUL",
       "seeAlso": [
@@ -1756,7 +1932,7 @@
       "reference": "./FSFULLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/FSFULLR.json",
-      "referenceNumber": "141",
+      "referenceNumber": "322",
       "name": "FSF Unlimited License (with License Retention)",
       "licenseId": "FSFULLR",
       "seeAlso": [
@@ -1769,7 +1945,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/FTL.json",
-      "referenceNumber": "142",
+      "referenceNumber": "394",
       "name": "Freetype Project License",
       "licenseId": "FTL",
       "seeAlso": [
@@ -1779,15 +1955,125 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./Fair.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Fair.json",
+      "referenceNumber": "270",
+      "name": "Fair License",
+      "licenseId": "Fair",
+      "seeAlso": [
+        "http://fairlicense.org/",
+        "https://opensource.org/licenses/Fair"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Frameworx-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Frameworx-1.0.json",
+      "referenceNumber": "392",
+      "name": "Frameworx Open License 1.0",
+      "licenseId": "Frameworx-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Frameworx-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./FreeBSD-DOC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/FreeBSD-DOC.json",
+      "referenceNumber": "194",
+      "name": "FreeBSD Documentation License",
+      "licenseId": "FreeBSD-DOC",
+      "seeAlso": [
+        "https://www.freebsd.org/copyright/freebsd-doc-license/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./FreeImage.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/FreeImage.json",
+      "referenceNumber": "391",
+      "name": "FreeImage Public License v1.0",
+      "licenseId": "FreeImage",
+      "seeAlso": [
+        "http://freeimage.sourceforge.net/freeimage-license.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
+      "referenceNumber": "265",
+      "name": "GNU Free Documentation License v1.1",
+      "licenseId": "GFDL-1.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-invariants-only.json",
+      "referenceNumber": "233",
+      "name": "GNU Free Documentation License v1.1 only - invariants",
+      "licenseId": "GFDL-1.1-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-invariants-or-later.json",
+      "referenceNumber": "78",
+      "name": "GNU Free Documentation License v1.1 or later - invariants",
+      "licenseId": "GFDL-1.1-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-no-invariants-only.json",
+      "referenceNumber": "13",
+      "name": "GNU Free Documentation License v1.1 only - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.1-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-no-invariants-or-later.json",
+      "referenceNumber": "250",
+      "name": "GNU Free Documentation License v1.1 or later - no invariants",
+      "licenseId": "GFDL-1.1-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./GFDL-1.1-only.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-only.json",
-      "referenceNumber": "143",
+      "referenceNumber": "101",
       "name": "GNU Free Documentation License v1.1 only",
       "licenseId": "GFDL-1.1-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
       ],
       "isOsiApproved": false
     },
@@ -1796,11 +2082,72 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.1-or-later.json",
-      "referenceNumber": "144",
+      "referenceNumber": "122",
       "name": "GNU Free Documentation License v1.1 or later",
       "licenseId": "GFDL-1.1-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
+      "referenceNumber": "202",
+      "name": "GNU Free Documentation License v1.2",
+      "licenseId": "GFDL-1.2",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-invariants-only.json",
+      "referenceNumber": "204",
+      "name": "GNU Free Documentation License v1.2 only - invariants",
+      "licenseId": "GFDL-1.2-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-invariants-or-later.json",
+      "referenceNumber": "428",
+      "name": "GNU Free Documentation License v1.2 or later - invariants",
+      "licenseId": "GFDL-1.2-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-no-invariants-only.json",
+      "referenceNumber": "321",
+      "name": "GNU Free Documentation License v1.2 only - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.2-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-no-invariants-or-later.json",
+      "referenceNumber": "190",
+      "name": "GNU Free Documentation License v1.2 or later - no invariants",
+      "licenseId": "GFDL-1.2-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
@@ -1809,11 +2156,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-only.json",
-      "referenceNumber": "145",
+      "referenceNumber": "92",
       "name": "GNU Free Documentation License v1.2 only",
       "licenseId": "GFDL-1.2-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
       ],
       "isOsiApproved": false
     },
@@ -1822,11 +2169,72 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.2-or-later.json",
-      "referenceNumber": "146",
+      "referenceNumber": "130",
       "name": "GNU Free Documentation License v1.2 or later",
       "licenseId": "GFDL-1.2-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
+      "referenceNumber": "384",
+      "name": "GNU Free Documentation License v1.3",
+      "licenseId": "GFDL-1.3",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-invariants-only.json",
+      "referenceNumber": "182",
+      "name": "GNU Free Documentation License v1.3 only - invariants",
+      "licenseId": "GFDL-1.3-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-invariants-or-later.json",
+      "referenceNumber": "316",
+      "name": "GNU Free Documentation License v1.3 or later - invariants",
+      "licenseId": "GFDL-1.3-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-no-invariants-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-no-invariants-only.json",
+      "referenceNumber": "178",
+      "name": "GNU Free Documentation License v1.3 only - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GFDL-1.3-no-invariants-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-no-invariants-or-later.json",
+      "referenceNumber": "162",
+      "name": "GNU Free Documentation License v1.3 or later - no invariants",
+      "licenseId": "GFDL-1.3-no-invariants-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1835,11 +2243,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-only.json",
-      "referenceNumber": "147",
+      "referenceNumber": "206",
       "name": "GNU Free Documentation License v1.3 only",
       "licenseId": "GFDL-1.3-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1848,23 +2256,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/GFDL-1.3-or-later.json",
-      "referenceNumber": "148",
+      "referenceNumber": "49",
       "name": "GNU Free Documentation License v1.3 or later",
       "licenseId": "GFDL-1.3-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Giftware.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
-      "referenceNumber": "149",
-      "name": "Giftware License",
-      "licenseId": "Giftware",
-      "seeAlso": [
-        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+        "https://www.gnu.org/licenses/fdl-1.3.txt"
       ],
       "isOsiApproved": false
     },
@@ -1872,7 +2268,7 @@
       "reference": "./GL2PS.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/GL2PS.json",
-      "referenceNumber": "150",
+      "referenceNumber": "338",
       "name": "GL2PS License",
       "licenseId": "GL2PS",
       "seeAlso": [
@@ -1881,10 +2277,276 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./GLWTPL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GLWTPL.json",
+      "referenceNumber": "48",
+      "name": "Good Luck With That Public License",
+      "licenseId": "GLWTPL",
+      "seeAlso": [
+        "https://github.com/me-shaon/GLWTPL/commit/da5f6bc734095efbacb442c0b31e33a65b9d6e85"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
+      "referenceNumber": "346",
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
+      "referenceNumber": "211",
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
+      "referenceNumber": "11",
+      "name": "GNU General Public License v1.0 only",
+      "licenseId": "GPL-1.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-1.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
+      "referenceNumber": "132",
+      "name": "GNU General Public License v1.0 or later",
+      "licenseId": "GPL-1.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
+      "referenceNumber": "374",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
+      "referenceNumber": "420",
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
+      "referenceNumber": "244",
+      "name": "GNU General Public License v2.0 only",
+      "licenseId": "GPL-2.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
+      "referenceNumber": "267",
+      "name": "GNU General Public License v2.0 or later",
+      "licenseId": "GPL-2.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
+        "https://opensource.org/licenses/GPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-2.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
+      "referenceNumber": "357",
+      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-2.0-with-GCC-exception",
+      "seeAlso": [
+        "https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
+      "referenceNumber": "29",
+      "name": "GNU General Public License v2.0 w/Autoconf exception",
+      "licenseId": "GPL-2.0-with-autoconf-exception",
+      "seeAlso": [
+        "http://ac-archive.sourceforge.net/doc/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-bison-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
+      "referenceNumber": "390",
+      "name": "GNU General Public License v2.0 w/Bison exception",
+      "licenseId": "GPL-2.0-with-bison-exception",
+      "seeAlso": [
+        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-classpath-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
+      "referenceNumber": "234",
+      "name": "GNU General Public License v2.0 w/Classpath exception",
+      "licenseId": "GPL-2.0-with-classpath-exception",
+      "seeAlso": [
+        "https://www.gnu.org/software/classpath/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-2.0-with-font-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
+      "referenceNumber": "18",
+      "name": "GNU General Public License v2.0 w/Font exception",
+      "licenseId": "GPL-2.0-with-font-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-faq.html#FontException"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./GPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
+      "referenceNumber": "434",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
+      "referenceNumber": "150",
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-only.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
+      "referenceNumber": "127",
+      "name": "GNU General Public License v3.0 only",
+      "licenseId": "GPL-3.0-only",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-or-later.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
+      "referenceNumber": "418",
+      "name": "GNU General Public License v3.0 or later",
+      "licenseId": "GPL-3.0-or-later",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gpl-3.0-standalone.html",
+        "https://opensource.org/licenses/GPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-with-GCC-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
+      "referenceNumber": "1",
+      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+      "licenseId": "GPL-3.0-with-GCC-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/gcc-exception-3.1.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./GPL-3.0-with-autoconf-exception.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
+      "referenceNumber": "6",
+      "name": "GNU General Public License v3.0 w/Autoconf exception",
+      "licenseId": "GPL-3.0-with-autoconf-exception",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/autoconf-exception-3.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Giftware.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Giftware.json",
+      "referenceNumber": "398",
+      "name": "Giftware License",
+      "licenseId": "Giftware",
+      "seeAlso": [
+        "http://liballeg.org/license.html#allegro-4-the-giftware-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./Glide.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glide.json",
-      "referenceNumber": "151",
+      "referenceNumber": "119",
       "name": "3dfx Glide License",
       "licenseId": "Glide",
       "seeAlso": [
@@ -1896,7 +2558,7 @@
       "reference": "./Glulxe.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Glulxe.json",
-      "referenceNumber": "152",
+      "referenceNumber": "213",
       "name": "Glulxe License",
       "licenseId": "Glulxe",
       "seeAlso": [
@@ -1905,107 +2567,39 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./gnuplot.html",
+      "reference": "./HPND.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
-      "referenceNumber": "153",
-      "name": "gnuplot License",
-      "licenseId": "gnuplot",
+      "detailsUrl": "http://spdx.org/licenses/HPND.json",
+      "referenceNumber": "152",
+      "name": "Historical Permission Notice and Disclaimer",
+      "licenseId": "HPND",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
+        "https://opensource.org/licenses/HPND"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./HPND-sell-variant.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/HPND-sell-variant.json",
+      "referenceNumber": "164",
+      "name": "Historical Permission Notice and Disclaimer - sell variant",
+      "licenseId": "HPND-sell-variant",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/net/sunrpc/auth_gss/gss_generic_token.c?h=v4.19"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-1.0-only.html",
+      "reference": "./HTMLTIDY.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-only.json",
-      "referenceNumber": "154",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0-only",
+      "detailsUrl": "http://spdx.org/licenses/HTMLTIDY.json",
+      "referenceNumber": "355",
+      "name": "HTML Tidy License",
+      "licenseId": "HTMLTIDY",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-1.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0-or-later.json",
-      "referenceNumber": "155",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-2.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-only.json",
-      "referenceNumber": "156",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-or-later.json",
-      "referenceNumber": "157",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-only.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-only.json",
-      "referenceNumber": "158",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0-only",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-or-later.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-or-later.json",
-      "referenceNumber": "159",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0-or-later",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./gSOAP-1.3b.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
-      "referenceNumber": "160",
-      "name": "gSOAP Public License v1.3b",
-      "licenseId": "gSOAP-1.3b",
-      "seeAlso": [
-        "http://www.cs.fsu.edu/~engelen/license.html"
+        "https://github.com/htacg/tidy-html5/blob/next/README/LICENSE.md"
       ],
       "isOsiApproved": false
     },
@@ -2013,7 +2607,7 @@
       "reference": "./HaskellReport.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/HaskellReport.json",
-      "referenceNumber": "161",
+      "referenceNumber": "218",
       "name": "Haskell Language Report License",
       "licenseId": "HaskellReport",
       "seeAlso": [
@@ -2022,23 +2616,23 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./HPND.html",
+      "reference": "./Hippocratic-2.1.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/HPND.json",
-      "referenceNumber": "162",
-      "name": "Historical Permission Notice and Disclaimer",
-      "licenseId": "HPND",
+      "detailsUrl": "http://spdx.org/licenses/Hippocratic-2.1.json",
+      "referenceNumber": "189",
+      "name": "Hippocratic License 2.1",
+      "licenseId": "Hippocratic-2.1",
       "seeAlso": [
-        "http://www.opensource.org/licenses/HPND"
+        "https://firstdonoharm.dev/version/2/1/license.html",
+        "https://github.com/EthicalSource/hippocratic-license/blob/58c0e646d64ff6fbee275bfe2b9492f914e3ab2a/LICENSE.txt"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./IBM-pibs.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/IBM-pibs.json",
-      "referenceNumber": "163",
+      "referenceNumber": "249",
       "name": "IBM PowerPC Initialization and Boot Software",
       "licenseId": "IBM-pibs",
       "seeAlso": [
@@ -2050,7 +2644,7 @@
       "reference": "./ICU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ICU.json",
-      "referenceNumber": "164",
+      "referenceNumber": "187",
       "name": "ICU License",
       "licenseId": "ICU",
       "seeAlso": [
@@ -2063,7 +2657,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IJG.json",
-      "referenceNumber": "165",
+      "referenceNumber": "252",
       "name": "Independent JPEG Group License",
       "licenseId": "IJG",
       "seeAlso": [
@@ -2072,102 +2666,15 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./ImageMagick.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
-      "referenceNumber": "166",
-      "name": "ImageMagick License",
-      "licenseId": "ImageMagick",
-      "seeAlso": [
-        "http://www.imagemagick.org/script/license.php"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./iMatix.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
-      "referenceNumber": "167",
-      "name": "iMatix Standard Function Library Agreement",
-      "licenseId": "iMatix",
-      "seeAlso": [
-        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Imlib2.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
-      "referenceNumber": "168",
-      "name": "Imlib2 License",
-      "licenseId": "Imlib2",
-      "seeAlso": [
-        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Info-ZIP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
-      "referenceNumber": "169",
-      "name": "Info-ZIP License",
-      "licenseId": "Info-ZIP",
-      "seeAlso": [
-        "http://www.info-zip.org/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel-ACPI.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
-      "referenceNumber": "170",
-      "name": "Intel ACPI Software License Agreement",
-      "licenseId": "Intel-ACPI",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Intel.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Intel.json",
-      "referenceNumber": "171",
-      "name": "Intel Open Source License",
-      "licenseId": "Intel",
-      "seeAlso": [
-        "http://opensource.org/licenses/Intel"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Interbase-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
-      "referenceNumber": "172",
-      "name": "Interbase Public License v1.0",
-      "licenseId": "Interbase-1.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./IPA.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPA.json",
-      "referenceNumber": "173",
+      "referenceNumber": "337",
       "name": "IPA Font License",
       "licenseId": "IPA",
       "seeAlso": [
-        "http://www.opensource.org/licenses/IPA"
+        "https://opensource.org/licenses/IPA"
       ],
       "isOsiApproved": true
     },
@@ -2176,11 +2683,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/IPL-1.0.json",
-      "referenceNumber": "174",
+      "referenceNumber": "336",
       "name": "IBM Public License v1.0",
       "licenseId": "IPL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/IPL-1.0"
+        "https://opensource.org/licenses/IPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2189,24 +2696,99 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ISC.json",
-      "referenceNumber": "175",
+      "referenceNumber": "385",
       "name": "ISC License",
       "licenseId": "ISC",
       "seeAlso": [
         "https://www.isc.org/downloads/software-support-policy/isc-license/",
-        "http://www.opensource.org/licenses/ISC"
+        "https://opensource.org/licenses/ISC"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./JasPer-2.0.html",
+      "reference": "./ImageMagick.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
-      "referenceNumber": "176",
-      "name": "JasPer License",
-      "licenseId": "JasPer-2.0",
+      "detailsUrl": "http://spdx.org/licenses/ImageMagick.json",
+      "referenceNumber": "353",
+      "name": "ImageMagick License",
+      "licenseId": "ImageMagick",
       "seeAlso": [
-        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+        "http://www.imagemagick.org/script/license.php"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Imlib2.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Imlib2.json",
+      "referenceNumber": "139",
+      "name": "Imlib2 License",
+      "licenseId": "Imlib2",
+      "seeAlso": [
+        "http://trac.enlightenment.org/e/browser/trunk/imlib2/COPYING",
+        "https://git.enlightenment.org/legacy/imlib2.git/tree/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Info-ZIP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Info-ZIP.json",
+      "referenceNumber": "306",
+      "name": "Info-ZIP License",
+      "licenseId": "Info-ZIP",
+      "seeAlso": [
+        "http://www.info-zip.org/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Intel.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Intel.json",
+      "referenceNumber": "25",
+      "name": "Intel Open Source License",
+      "licenseId": "Intel",
+      "seeAlso": [
+        "https://opensource.org/licenses/Intel"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Intel-ACPI.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Intel-ACPI.json",
+      "referenceNumber": "251",
+      "name": "Intel ACPI Software License Agreement",
+      "licenseId": "Intel-ACPI",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Intel_ACPI_Software_License_Agreement"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Interbase-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Interbase-1.0.json",
+      "referenceNumber": "350",
+      "name": "Interbase Public License v1.0",
+      "licenseId": "Interbase-1.0",
+      "seeAlso": [
+        "https://web.archive.org/web/20060319014854/http://info.borland.com/devsupport/interbase/opensource/IPL.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./JPNIC.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JPNIC.json",
+      "referenceNumber": "343",
+      "name": "Japan Network Information Center License",
+      "licenseId": "JPNIC",
+      "seeAlso": [
+        "https://gitlab.isc.org/isc-projects/bind9/blob/master/COPYRIGHT#L366"
       ],
       "isOsiApproved": false
     },
@@ -2214,7 +2796,7 @@
       "reference": "./JSON.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/JSON.json",
-      "referenceNumber": "177",
+      "referenceNumber": "210",
       "name": "JSON License",
       "licenseId": "JSON",
       "seeAlso": [
@@ -2223,10 +2805,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./JasPer-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/JasPer-2.0.json",
+      "referenceNumber": "77",
+      "name": "JasPer License",
+      "licenseId": "JasPer-2.0",
+      "seeAlso": [
+        "http://www.ece.uvic.ca/~mdadams/jasper/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./LAL-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.2.json",
-      "referenceNumber": "178",
+      "referenceNumber": "158",
       "name": "Licence Art Libre 1.2",
       "licenseId": "LAL-1.2",
       "seeAlso": [
@@ -2238,47 +2832,47 @@
       "reference": "./LAL-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LAL-1.3.json",
-      "referenceNumber": "179",
+      "referenceNumber": "387",
       "name": "Licence Art Libre 1.3",
       "licenseId": "LAL-1.3",
       "seeAlso": [
-        "http://artlibre.org/"
+        "https://artlibre.org/"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./Latex2e.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
-      "referenceNumber": "180",
-      "name": "Latex2e License",
-      "licenseId": "Latex2e",
+      "reference": "./LGPL-2.0.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
+      "referenceNumber": "300",
+      "name": "GNU Library General Public License v2 only",
+      "licenseId": "LGPL-2.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Latex2e"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
-      "reference": "./Leptonica.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
-      "referenceNumber": "181",
-      "name": "Leptonica License",
-      "licenseId": "Leptonica",
+      "reference": "./LGPL-2.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
+      "referenceNumber": "142",
+      "name": "GNU Library General Public License v2 or later",
+      "licenseId": "LGPL-2.0+",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./LGPL-2.0-only.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-only.json",
-      "referenceNumber": "182",
+      "referenceNumber": "362",
       "name": "GNU Library General Public License v2 only",
       "licenseId": "LGPL-2.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
       ],
       "isOsiApproved": true
     },
@@ -2286,11 +2880,38 @@
       "reference": "./LGPL-2.0-or-later.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.0-or-later.json",
-      "referenceNumber": "183",
+      "referenceNumber": "30",
       "name": "GNU Library General Public License v2 or later",
       "licenseId": "LGPL-2.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
+      "referenceNumber": "197",
+      "name": "GNU Lesser General Public License v2.1 only",
+      "licenseId": "LGPL-2.1",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-2.1+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
+      "referenceNumber": "215",
+      "name": "GNU Library General Public License v2.1 or later",
+      "licenseId": "LGPL-2.1+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2299,12 +2920,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-only.json",
-      "referenceNumber": "184",
+      "referenceNumber": "141",
       "name": "GNU Lesser General Public License v2.1 only",
       "licenseId": "LGPL-2.1-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -2313,12 +2934,39 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-2.1-or-later.json",
-      "referenceNumber": "185",
+      "referenceNumber": "288",
       "name": "GNU Lesser General Public License v2.1 or later",
       "licenseId": "LGPL-2.1-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
+        "https://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
+        "https://opensource.org/licenses/LGPL-2.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0.html",
+      "isDeprecatedLicenseId": true,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
+      "referenceNumber": "222",
+      "name": "GNU Lesser General Public License v3.0 only",
+      "licenseId": "LGPL-3.0",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LGPL-3.0+.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
+      "referenceNumber": "236",
+      "name": "GNU Lesser General Public License v3.0 or later",
+      "licenseId": "LGPL-3.0+",
+      "seeAlso": [
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2327,12 +2975,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-only.json",
-      "referenceNumber": "186",
+      "referenceNumber": "46",
       "name": "GNU Lesser General Public License v3.0 only",
       "licenseId": "LGPL-3.0-only",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2341,12 +2989,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LGPL-3.0-or-later.json",
-      "referenceNumber": "187",
+      "referenceNumber": "344",
       "name": "GNU Lesser General Public License v3.0 or later",
       "licenseId": "LGPL-3.0-or-later",
       "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
+        "https://www.gnu.org/licenses/lgpl-3.0-standalone.html",
+        "https://opensource.org/licenses/LGPL-3.0"
       ],
       "isOsiApproved": true
     },
@@ -2354,7 +3002,7 @@
       "reference": "./LGPLLR.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LGPLLR.json",
-      "referenceNumber": "188",
+      "referenceNumber": "438",
       "name": "Lesser General Public License For Linguistic Resources",
       "licenseId": "LGPLLR",
       "seeAlso": [
@@ -2363,89 +3011,14 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Libpng.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
-      "referenceNumber": "189",
-      "name": "libpng License",
-      "licenseId": "Libpng",
-      "seeAlso": [
-        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./libtiff.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
-      "referenceNumber": "190",
-      "name": "libtiff License",
-      "licenseId": "libtiff",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/libtiff"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./LiLiQ-P-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
-      "referenceNumber": "191",
-      "name": "Licence Libre du Québec – Permissive version 1.1",
-      "licenseId": "LiLiQ-P-1.1",
-      "seeAlso": [
-        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-P-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-R-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
-      "referenceNumber": "192",
-      "name": "Licence Libre du Québec – Réciprocité version 1.1",
-      "licenseId": "LiLiQ-R-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-R-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LiLiQ-Rplus-1.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
-      "referenceNumber": "193",
-      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
-      "licenseId": "LiLiQ-Rplus-1.1",
-      "seeAlso": [
-        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
-        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Linux-OpenIB.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
-      "referenceNumber": "194",
-      "name": "Linux Kernel Variant of OpenIB.org license",
-      "licenseId": "Linux-OpenIB",
-      "seeAlso": [
-        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./LPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.0.json",
-      "referenceNumber": "195",
+      "referenceNumber": "402",
       "name": "Lucent Public License Version 1.0",
       "licenseId": "LPL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/LPL-1.0"
+        "https://opensource.org/licenses/LPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2454,12 +3027,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPL-1.02.json",
-      "referenceNumber": "196",
+      "referenceNumber": "125",
       "name": "Lucent Public License v1.02",
       "licenseId": "LPL-1.02",
       "seeAlso": [
         "http://plan9.bell-labs.com/plan9/license.html",
-        "http://www.opensource.org/licenses/LPL-1.02"
+        "https://opensource.org/licenses/LPL-1.02"
       ],
       "isOsiApproved": true
     },
@@ -2467,7 +3040,7 @@
       "reference": "./LPPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.0.json",
-      "referenceNumber": "197",
+      "referenceNumber": "88",
       "name": "LaTeX Project Public License v1.0",
       "licenseId": "LPPL-1.0",
       "seeAlso": [
@@ -2479,7 +3052,7 @@
       "reference": "./LPPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.1.json",
-      "referenceNumber": "198",
+      "referenceNumber": "176",
       "name": "LaTeX Project Public License v1.1",
       "licenseId": "LPPL-1.1",
       "seeAlso": [
@@ -2492,7 +3065,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.2.json",
-      "referenceNumber": "199",
+      "referenceNumber": "167",
       "name": "LaTeX Project Public License v1.2",
       "licenseId": "LPPL-1.2",
       "seeAlso": [
@@ -2505,7 +3078,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3a.json",
-      "referenceNumber": "200",
+      "referenceNumber": "289",
       "name": "LaTeX Project Public License v1.3a",
       "licenseId": "LPPL-1.3a",
       "seeAlso": [
@@ -2517,36 +3090,112 @@
       "reference": "./LPPL-1.3c.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/LPPL-1.3c.json",
-      "referenceNumber": "201",
+      "referenceNumber": "129",
       "name": "LaTeX Project Public License v1.3c",
       "licenseId": "LPPL-1.3c",
       "seeAlso": [
         "http://www.latex-project.org/lppl/lppl-1-3c.txt",
-        "http://www.opensource.org/licenses/LPPL-1.3c"
+        "https://opensource.org/licenses/LPPL-1.3c"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./MakeIndex.html",
+      "reference": "./Latex2e.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
-      "referenceNumber": "202",
-      "name": "MakeIndex License",
-      "licenseId": "MakeIndex",
+      "detailsUrl": "http://spdx.org/licenses/Latex2e.json",
+      "referenceNumber": "32",
+      "name": "Latex2e License",
+      "licenseId": "Latex2e",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+        "https://fedoraproject.org/wiki/Licensing/Latex2e"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./MirOS.html",
+      "reference": "./Leptonica.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
-      "referenceNumber": "203",
-      "name": "MirOS License",
-      "licenseId": "MirOS",
+      "detailsUrl": "http://spdx.org/licenses/Leptonica.json",
+      "referenceNumber": "325",
+      "name": "Leptonica License",
+      "licenseId": "Leptonica",
       "seeAlso": [
-        "http://www.opensource.org/licenses/MirOS"
+        "https://fedoraproject.org/wiki/Licensing/Leptonica"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./LiLiQ-P-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-P-1.1.json",
+      "referenceNumber": "445",
+      "name": "Licence Libre du Québec – Permissive version 1.1",
+      "licenseId": "LiLiQ-P-1.1",
+      "seeAlso": [
+        "https://forge.gouv.qc.ca/licence/fr/liliq-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-P-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-R-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-R-1.1.json",
+      "referenceNumber": "315",
+      "name": "Licence Libre du Québec – Réciprocité version 1.1",
+      "licenseId": "LiLiQ-R-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-R-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./LiLiQ-Rplus-1.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/LiLiQ-Rplus-1.1.json",
+      "referenceNumber": "363",
+      "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+      "licenseId": "LiLiQ-Rplus-1.1",
+      "seeAlso": [
+        "https://www.forge.gouv.qc.ca/participez/licence-logicielle/licence-libre-du-quebec-liliq-en-francais/licence-libre-du-quebec-reciprocite-forte-liliq-r-v1-1/",
+        "http://opensource.org/licenses/LiLiQ-Rplus-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Libpng.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Libpng.json",
+      "referenceNumber": "407",
+      "name": "libpng License",
+      "licenseId": "Libpng",
+      "seeAlso": [
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Linux-OpenIB.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Linux-OpenIB.json",
+      "referenceNumber": "230",
+      "name": "Linux Kernel Variant of OpenIB.org license",
+      "licenseId": "Linux-OpenIB",
+      "seeAlso": [
+        "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/drivers/infiniband/core/sa.h"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MIT.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/MIT.json",
+      "referenceNumber": "273",
+      "name": "MIT License",
+      "licenseId": "MIT",
+      "seeAlso": [
+        "https://opensource.org/licenses/MIT"
       ],
       "isOsiApproved": true
     },
@@ -2554,7 +3203,7 @@
       "reference": "./MIT-0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-0.json",
-      "referenceNumber": "204",
+      "referenceNumber": "80",
       "name": "MIT No Attribution",
       "licenseId": "MIT-0",
       "seeAlso": [
@@ -2563,6 +3212,19 @@
         "https://github.com/awsdocs/aws-cloud9-user-guide/blob/master/LICENSE-SAMPLECODE"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./MIT-CMU.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
+      "referenceNumber": "373",
+      "name": "CMU License",
+      "licenseId": "MIT-CMU",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style",
+        "https://github.com/python-pillow/Pillow/blob/fffb426092c8db24a5f4b6df243a8a3c01fb63cd/LICENSE"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./MIT-advertising.html",
@@ -2577,22 +3239,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MIT-CMU.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MIT-CMU.json",
-      "referenceNumber": "206",
-      "name": "CMU License",
-      "licenseId": "MIT-CMU",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing:MIT?rd=Licensing/MIT#CMU_Style"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./MIT-enna.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-enna.json",
-      "referenceNumber": "207",
+      "referenceNumber": "62",
       "name": "enna License",
       "licenseId": "MIT-enna",
       "seeAlso": [
@@ -2604,7 +3254,7 @@
       "reference": "./MIT-feh.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MIT-feh.json",
-      "referenceNumber": "208",
+      "referenceNumber": "404",
       "name": "feh License",
       "licenseId": "MIT-feh",
       "seeAlso": [
@@ -2613,23 +3263,25 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./MIT.html",
+      "reference": "./MIT-open-group.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/MIT.json",
-      "referenceNumber": "209",
-      "name": "MIT License",
-      "licenseId": "MIT",
+      "detailsUrl": "http://spdx.org/licenses/MIT-open-group.json",
+      "referenceNumber": "329",
+      "name": "MIT Open Group variant",
+      "licenseId": "MIT-open-group",
       "seeAlso": [
-        "http://www.opensource.org/licenses/MIT"
+        "https://gitlab.freedesktop.org/xorg/app/iceauth/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xvinfo/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xsetroot/-/blob/master/COPYING",
+        "https://gitlab.freedesktop.org/xorg/app/xauth/-/blob/master/COPYING"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./MITNFA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MITNFA.json",
-      "referenceNumber": "210",
+      "referenceNumber": "364",
       "name": "MIT +no-false-attribs license",
       "licenseId": "MITNFA",
       "seeAlso": [
@@ -2638,39 +3290,15 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Motosoto.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
-      "referenceNumber": "211",
-      "name": "Motosoto License",
-      "licenseId": "Motosoto",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Motosoto"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./mpich2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
-      "referenceNumber": "212",
-      "name": "mpich2 License",
-      "licenseId": "mpich2",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/MIT"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./MPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.0.json",
-      "referenceNumber": "213",
+      "referenceNumber": "255",
       "name": "Mozilla Public License 1.0",
       "licenseId": "MPL-1.0",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.0.html",
-        "http://opensource.org/licenses/MPL-1.0"
+        "https://opensource.org/licenses/MPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -2679,25 +3307,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-1.1.json",
-      "referenceNumber": "214",
+      "referenceNumber": "435",
       "name": "Mozilla Public License 1.1",
       "licenseId": "MPL-1.1",
       "seeAlso": [
         "http://www.mozilla.org/MPL/MPL-1.1.html",
-        "http://www.opensource.org/licenses/MPL-1.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./MPL-2.0-no-copyleft-exception.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
-      "referenceNumber": "215",
-      "name": "Mozilla Public License 2.0 (no copyleft exception)",
-      "licenseId": "MPL-2.0-no-copyleft-exception",
-      "seeAlso": [
-        "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/licenses/MPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -2706,12 +3321,25 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MPL-2.0.json",
-      "referenceNumber": "216",
+      "referenceNumber": "134",
       "name": "Mozilla Public License 2.0",
       "licenseId": "MPL-2.0",
       "seeAlso": [
         "http://www.mozilla.org/MPL/2.0/",
-        "http://opensource.org/licenses/MPL-2.0"
+        "https://opensource.org/licenses/MPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MPL-2.0-no-copyleft-exception.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MPL-2.0-no-copyleft-exception.json",
+      "referenceNumber": "193",
+      "name": "Mozilla Public License 2.0 (no copyleft exception)",
+      "licenseId": "MPL-2.0-no-copyleft-exception",
+      "seeAlso": [
+        "http://www.mozilla.org/MPL/2.0/",
+        "https://opensource.org/licenses/MPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -2720,12 +3348,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-PL.json",
-      "referenceNumber": "217",
+      "referenceNumber": "396",
       "name": "Microsoft Public License",
       "licenseId": "MS-PL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-PL"
+        "https://opensource.org/licenses/MS-PL"
       ],
       "isOsiApproved": true
     },
@@ -2734,12 +3362,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/MS-RL.json",
-      "referenceNumber": "218",
+      "referenceNumber": "4",
       "name": "Microsoft Reciprocal License",
       "licenseId": "MS-RL",
       "seeAlso": [
         "http://www.microsoft.com/opensource/licenses.mspx",
-        "http://www.opensource.org/licenses/MS-RL"
+        "https://opensource.org/licenses/MS-RL"
       ],
       "isOsiApproved": true
     },
@@ -2747,7 +3375,7 @@
       "reference": "./MTLL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/MTLL.json",
-      "referenceNumber": "219",
+      "referenceNumber": "104",
       "name": "Matrix Template Library License",
       "licenseId": "MTLL",
       "seeAlso": [
@@ -2756,14 +3384,75 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./MakeIndex.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MakeIndex.json",
+      "referenceNumber": "372",
+      "name": "MakeIndex License",
+      "licenseId": "MakeIndex",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/MakeIndex"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MirOS.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MirOS.json",
+      "referenceNumber": "400",
+      "name": "The MirOS Licence",
+      "licenseId": "MirOS",
+      "seeAlso": [
+        "https://opensource.org/licenses/MirOS"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Motosoto.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Motosoto.json",
+      "referenceNumber": "28",
+      "name": "Motosoto License",
+      "licenseId": "Motosoto",
+      "seeAlso": [
+        "https://opensource.org/licenses/Motosoto"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./MulanPSL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MulanPSL-1.0.json",
+      "referenceNumber": "216",
+      "name": "Mulan Permissive Software License, Version 1",
+      "licenseId": "MulanPSL-1.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL/",
+        "https://github.com/yuwenlong/longphp/blob/25dfb70cc2a466dc4bb55ba30901cbce08d164b5/LICENSE"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./MulanPSL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/MulanPSL-2.0.json",
+      "referenceNumber": "155",
+      "name": "Mulan Permissive Software License, Version 2",
+      "licenseId": "MulanPSL-2.0",
+      "seeAlso": [
+        "https://license.coscl.org.cn/MulanPSL2/"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./Multics.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Multics.json",
-      "referenceNumber": "220",
+      "referenceNumber": "448",
       "name": "Multics License",
       "licenseId": "Multics",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Multics"
+        "https://opensource.org/licenses/Multics"
       ],
       "isOsiApproved": true
     },
@@ -2771,7 +3460,7 @@
       "reference": "./Mup.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Mup.json",
-      "referenceNumber": "221",
+      "referenceNumber": "331",
       "name": "Mup License",
       "licenseId": "Mup",
       "seeAlso": [
@@ -2783,24 +3472,12 @@
       "reference": "./NASA-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NASA-1.3.json",
-      "referenceNumber": "222",
+      "referenceNumber": "124",
       "name": "NASA Open Source Agreement 1.3",
       "licenseId": "NASA-1.3",
       "seeAlso": [
         "http://ti.arc.nasa.gov/opensource/nosa/",
-        "http://www.opensource.org/licenses/NASA-1.3"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Naumen.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
-      "referenceNumber": "223",
-      "name": "Naumen Public License",
-      "licenseId": "Naumen",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/Naumen"
+        "https://opensource.org/licenses/NASA-1.3"
       ],
       "isOsiApproved": true
     },
@@ -2808,7 +3485,7 @@
       "reference": "./NBPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NBPL-1.0.json",
-      "referenceNumber": "224",
+      "referenceNumber": "52",
       "name": "Net Boolean Public License v1",
       "licenseId": "NBPL-1.0",
       "seeAlso": [
@@ -2817,72 +3494,74 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./NCGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NCGL-UK-2.0.json",
+      "referenceNumber": "231",
+      "name": "Non-Commercial Government Licence",
+      "licenseId": "NCGL-UK-2.0",
+      "seeAlso": [
+        "https://github.com/spdx/license-list-XML/blob/master/src/Apache-2.0.xml"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./NCSA.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NCSA.json",
-      "referenceNumber": "225",
+      "referenceNumber": "200",
       "name": "University of Illinois/NCSA Open Source License",
       "licenseId": "NCSA",
       "seeAlso": [
         "http://otm.illinois.edu/uiuc_openSource",
-        "http://www.opensource.org/licenses/NCSA"
+        "https://opensource.org/licenses/NCSA"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./Net-SNMP.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
-      "referenceNumber": "226",
-      "name": "Net-SNMP License",
-      "licenseId": "Net-SNMP",
-      "seeAlso": [
-        "http://net-snmp.sourceforge.net/about/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./NetCDF.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
-      "referenceNumber": "227",
-      "name": "NetCDF license",
-      "licenseId": "NetCDF",
-      "seeAlso": [
-        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Newsletr.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
-      "referenceNumber": "228",
-      "name": "Newsletr License",
-      "licenseId": "Newsletr",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Newsletr"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./NGPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NGPL.json",
-      "referenceNumber": "229",
+      "referenceNumber": "335",
       "name": "Nethack General Public License",
       "licenseId": "NGPL",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NGPL"
+        "https://opensource.org/licenses/NGPL"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./NIST-PD.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NIST-PD.json",
+      "referenceNumber": "317",
+      "name": "NIST Public Domain Notice",
+      "licenseId": "NIST-PD",
+      "seeAlso": [
+        "https://github.com/tcheneau/simpleRPL/blob/e645e69e38dd4e3ccfeceb2db8cba05b7c2e0cd3/LICENSE.txt",
+        "https://github.com/tcheneau/Routing/blob/f09f46fcfe636107f22f2c98348188a65a135d98/README.md"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NIST-PD-fallback.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NIST-PD-fallback.json",
+      "referenceNumber": "31",
+      "name": "NIST Public Domain Notice with license fallback",
+      "licenseId": "NIST-PD-fallback",
+      "seeAlso": [
+        "https://github.com/usnistgov/jsip/blob/59700e6926cbe96c5cdae897d9a7d2656b42abe3/LICENSE",
+        "https://github.com/usnistgov/fipy/blob/86aaa5c2ba2c6f1be19593c5986071cf6568cc34/LICENSE.rst"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./NLOD-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLOD-1.0.json",
-      "referenceNumber": "230",
+      "referenceNumber": "151",
       "name": "Norwegian Licence for Open Government Data",
       "licenseId": "NLOD-1.0",
       "seeAlso": [
@@ -2894,7 +3573,7 @@
       "reference": "./NLPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NLPL.json",
-      "referenceNumber": "231",
+      "referenceNumber": "332",
       "name": "No Limit Public License",
       "licenseId": "NLPL",
       "seeAlso": [
@@ -2903,24 +3582,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Nokia.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
-      "referenceNumber": "232",
-      "name": "Nokia Open Source License",
-      "licenseId": "Nokia",
-      "seeAlso": [
-        "http://www.opensource.org/licenses/nokia"
-      ],
-      "isOsiApproved": true
-    },
-    {
       "reference": "./NOSL.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NOSL.json",
-      "referenceNumber": "233",
+      "referenceNumber": "411",
       "name": "Netizen Open Source License",
       "licenseId": "NOSL",
       "seeAlso": [
@@ -2929,23 +3595,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Noweb.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
-      "referenceNumber": "234",
-      "name": "Noweb License",
-      "licenseId": "Noweb",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Noweb"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./NPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.0.json",
-      "referenceNumber": "235",
+      "referenceNumber": "263",
       "name": "Netscape Public License v1.0",
       "licenseId": "NPL-1.0",
       "seeAlso": [
@@ -2958,7 +3612,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/NPL-1.1.json",
-      "referenceNumber": "236",
+      "referenceNumber": "446",
       "name": "Netscape Public License v1.1",
       "licenseId": "NPL-1.1",
       "seeAlso": [
@@ -2970,11 +3624,11 @@
       "reference": "./NPOSL-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NPOSL-3.0.json",
-      "referenceNumber": "237",
+      "referenceNumber": "165",
       "name": "Non-Profit Open Software License 3.0",
       "licenseId": "NPOSL-3.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NOSL3.0"
+        "https://opensource.org/licenses/NOSL3.0"
       ],
       "isOsiApproved": true
     },
@@ -2982,7 +3636,7 @@
       "reference": "./NRL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NRL.json",
-      "referenceNumber": "238",
+      "referenceNumber": "103",
       "name": "NRL License",
       "licenseId": "NRL",
       "seeAlso": [
@@ -2994,19 +3648,128 @@
       "reference": "./NTP.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/NTP.json",
-      "referenceNumber": "239",
+      "referenceNumber": "277",
       "name": "NTP License",
       "licenseId": "NTP",
       "seeAlso": [
-        "http://www.opensource.org/licenses/NTP"
+        "https://opensource.org/licenses/NTP"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./NTP-0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NTP-0.json",
+      "referenceNumber": "196",
+      "name": "NTP No Attribution",
+      "licenseId": "NTP-0",
+      "seeAlso": [
+        "https://github.com/tytso/e2fsprogs/blob/master/lib/et/et_name.c"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Naumen.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Naumen.json",
+      "referenceNumber": "303",
+      "name": "Naumen Public License",
+      "licenseId": "Naumen",
+      "seeAlso": [
+        "https://opensource.org/licenses/Naumen"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Net-SNMP.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Net-SNMP.json",
+      "referenceNumber": "297",
+      "name": "Net-SNMP License",
+      "licenseId": "Net-SNMP",
+      "seeAlso": [
+        "http://net-snmp.sourceforge.net/about/license.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./NetCDF.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/NetCDF.json",
+      "referenceNumber": "226",
+      "name": "NetCDF license",
+      "licenseId": "NetCDF",
+      "seeAlso": [
+        "http://www.unidata.ucar.edu/software/netcdf/copyright.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Newsletr.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Newsletr.json",
+      "referenceNumber": "388",
+      "name": "Newsletr License",
+      "licenseId": "Newsletr",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Newsletr"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nokia.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Nokia.json",
+      "referenceNumber": "128",
+      "name": "Nokia Open Source License",
+      "licenseId": "Nokia",
+      "seeAlso": [
+        "https://opensource.org/licenses/nokia"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Noweb.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Noweb.json",
+      "referenceNumber": "71",
+      "name": "Noweb License",
+      "licenseId": "Noweb",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Noweb"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Nunit.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/Nunit.json",
+      "referenceNumber": "89",
+      "name": "Nunit License",
+      "licenseId": "Nunit",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Nunit"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./O-UDA-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/O-UDA-1.0.json",
+      "referenceNumber": "43",
+      "name": "Open Use of Data Agreement v1.0",
+      "licenseId": "O-UDA-1.0",
+      "seeAlso": [
+        "https://github.com/microsoft/Open-Use-of-Data-Agreement/blob/v1.0/O-UDA-1.0.md"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./OCCT-PL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCCT-PL.json",
-      "referenceNumber": "240",
+      "referenceNumber": "177",
       "name": "Open CASCADE Technology Public License",
       "licenseId": "OCCT-PL",
       "seeAlso": [
@@ -3018,25 +3781,38 @@
       "reference": "./OCLC-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OCLC-2.0.json",
-      "referenceNumber": "241",
+      "referenceNumber": "370",
       "name": "OCLC Research Public License 2.0",
       "licenseId": "OCLC-2.0",
       "seeAlso": [
         "http://www.oclc.org/research/activities/software/license/v2final.htm",
-        "http://www.opensource.org/licenses/OCLC-2.0"
+        "https://opensource.org/licenses/OCLC-2.0"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./ODC-By-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/ODC-By-1.0.json",
+      "referenceNumber": "412",
+      "name": "Open Data Commons Attribution License v1.0",
+      "licenseId": "ODC-By-1.0",
+      "seeAlso": [
+        "https://opendatacommons.org/licenses/by/1.0/"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./ODbL-1.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ODbL-1.0.json",
-      "referenceNumber": "242",
-      "name": "ODC Open Database License v1.0",
+      "referenceNumber": "369",
+      "name": "Open Data Commons Open Database License v1.0",
       "licenseId": "ODbL-1.0",
       "seeAlso": [
-        "http://www.opendatacommons.org/licenses/odbl/1.0/"
+        "http://www.opendatacommons.org/licenses/odbl/1.0/",
+        "https://opendatacommons.org/licenses/odbl/1-0/"
       ],
       "isOsiApproved": false
     },
@@ -3044,9 +3820,33 @@
       "reference": "./OFL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.0.json",
-      "referenceNumber": "243",
+      "referenceNumber": "83",
       "name": "SIL Open Font License 1.0",
       "licenseId": "OFL-1.0",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.0-RFN.json",
+      "referenceNumber": "324",
+      "name": "SIL Open Font License 1.0 with Reserved Font Name",
+      "licenseId": "OFL-1.0-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OFL-1.0-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.0-no-RFN.json",
+      "referenceNumber": "72",
+      "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+      "licenseId": "OFL-1.0-no-RFN",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL10_web"
       ],
@@ -3057,25 +3857,111 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OFL-1.1.json",
-      "referenceNumber": "244",
+      "referenceNumber": "356",
       "name": "SIL Open Font License 1.1",
       "licenseId": "OFL-1.1",
       "seeAlso": [
         "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
-        "http://www.opensource.org/licenses/OFL-1.1"
+        "https://opensource.org/licenses/OFL-1.1"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./OFL-1.1-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.1-RFN.json",
+      "referenceNumber": "42",
+      "name": "SIL Open Font License 1.1 with Reserved Font Name",
+      "licenseId": "OFL-1.1-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OFL-1.1-no-RFN.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OFL-1.1-no-RFN.json",
+      "referenceNumber": "254",
+      "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+      "licenseId": "OFL-1.1-no-RFN",
+      "seeAlso": [
+        "http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web",
+        "https://opensource.org/licenses/OFL-1.1"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./OGC-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGC-1.0.json",
+      "referenceNumber": "397",
+      "name": "OGC Software License, Version 1.0",
+      "licenseId": "OGC-1.0",
+      "seeAlso": [
+        "https://www.ogc.org/ogc/software/1.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-Canada-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-Canada-2.0.json",
+      "referenceNumber": "376",
+      "name": "Open Government Licence - Canada",
+      "licenseId": "OGL-Canada-2.0",
+      "seeAlso": [
+        "https://open.canada.ca/en/open-government-licence-canada"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-1.0.json",
+      "referenceNumber": "378",
+      "name": "Open Government Licence v1.0",
+      "licenseId": "OGL-UK-1.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/1/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-2.0.json",
+      "referenceNumber": "33",
+      "name": "Open Government Licence v2.0",
+      "licenseId": "OGL-UK-2.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/2/"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./OGL-UK-3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OGL-UK-3.0.json",
+      "referenceNumber": "114",
+      "name": "Open Government Licence v3.0",
+      "licenseId": "OGL-UK-3.0",
+      "seeAlso": [
+        "http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./OGTSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OGTSL.json",
-      "referenceNumber": "245",
+      "referenceNumber": "22",
       "name": "Open Group Test Suite License",
       "licenseId": "OGTSL",
       "seeAlso": [
         "http://www.opengroup.org/testing/downloads/The_Open_Group_TSL.txt",
-        "http://www.opensource.org/licenses/OGTSL"
+        "https://opensource.org/licenses/OGTSL"
       ],
       "isOsiApproved": true
     },
@@ -3083,7 +3969,7 @@
       "reference": "./OLDAP-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.1.json",
-      "referenceNumber": "246",
+      "referenceNumber": "54",
       "name": "Open LDAP Public License v1.1",
       "licenseId": "OLDAP-1.1",
       "seeAlso": [
@@ -3095,7 +3981,7 @@
       "reference": "./OLDAP-1.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.2.json",
-      "referenceNumber": "247",
+      "referenceNumber": "45",
       "name": "Open LDAP Public License v1.2",
       "licenseId": "OLDAP-1.2",
       "seeAlso": [
@@ -3107,7 +3993,7 @@
       "reference": "./OLDAP-1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.3.json",
-      "referenceNumber": "248",
+      "referenceNumber": "38",
       "name": "Open LDAP Public License v1.3",
       "licenseId": "OLDAP-1.3",
       "seeAlso": [
@@ -3119,7 +4005,7 @@
       "reference": "./OLDAP-1.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-1.4.json",
-      "referenceNumber": "249",
+      "referenceNumber": "248",
       "name": "Open LDAP Public License v1.4",
       "licenseId": "OLDAP-1.4",
       "seeAlso": [
@@ -3128,22 +4014,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.0.1.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
-      "referenceNumber": "250",
-      "name": "Open LDAP Public License v2.0.1",
-      "licenseId": "OLDAP-2.0.1",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b6d68acd14e51ca3aab4428bf26522aa74873f0e"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./OLDAP-2.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.json",
-      "referenceNumber": "251",
+      "referenceNumber": "21",
       "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
       "licenseId": "OLDAP-2.0",
       "seeAlso": [
@@ -3152,10 +4026,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./OLDAP-2.0.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.0.1.json",
+      "referenceNumber": "299",
+      "name": "Open LDAP Public License v2.0.1",
+      "licenseId": "OLDAP-2.0.1",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=b6d68acd14e51ca3aab4428bf26522aa74873f0e"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./OLDAP-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.1.json",
-      "referenceNumber": "252",
+      "referenceNumber": "433",
       "name": "Open LDAP Public License v2.1",
       "licenseId": "OLDAP-2.1",
       "seeAlso": [
@@ -3164,10 +4050,22 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./OLDAP-2.2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
+      "referenceNumber": "345",
+      "name": "Open LDAP Public License v2.2",
+      "licenseId": "OLDAP-2.2",
+      "seeAlso": [
+        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=470b0c18ec67621c85881b2733057fecf4a1acc3"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./OLDAP-2.2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.1.json",
-      "referenceNumber": "253",
+      "referenceNumber": "415",
       "name": "Open LDAP Public License v2.2.1",
       "licenseId": "OLDAP-2.2.1",
       "seeAlso": [
@@ -3179,7 +4077,7 @@
       "reference": "./OLDAP-2.2.2.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.2.json",
-      "referenceNumber": "254",
+      "referenceNumber": "179",
       "name": "Open LDAP Public License 2.2.2",
       "licenseId": "OLDAP-2.2.2",
       "seeAlso": [
@@ -3188,23 +4086,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OLDAP-2.2.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/OLDAP-2.2.json",
-      "referenceNumber": "255",
-      "name": "Open LDAP Public License v2.2",
-      "licenseId": "OLDAP-2.2",
-      "seeAlso": [
-        "http://www.openldap.org/devel/gitweb.cgi?p=openldap.git;a=blob;f=LICENSE;hb=470b0c18ec67621c85881b2733057fecf4a1acc3"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./OLDAP-2.3.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.3.json",
-      "referenceNumber": "256",
+      "referenceNumber": "333",
       "name": "Open LDAP Public License v2.3",
       "licenseId": "OLDAP-2.3",
       "seeAlso": [
@@ -3216,7 +4102,7 @@
       "reference": "./OLDAP-2.4.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.4.json",
-      "referenceNumber": "257",
+      "referenceNumber": "121",
       "name": "Open LDAP Public License v2.4",
       "licenseId": "OLDAP-2.4",
       "seeAlso": [
@@ -3228,7 +4114,7 @@
       "reference": "./OLDAP-2.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.5.json",
-      "referenceNumber": "258",
+      "referenceNumber": "111",
       "name": "Open LDAP Public License v2.5",
       "licenseId": "OLDAP-2.5",
       "seeAlso": [
@@ -3240,7 +4126,7 @@
       "reference": "./OLDAP-2.6.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.6.json",
-      "referenceNumber": "259",
+      "referenceNumber": "112",
       "name": "Open LDAP Public License v2.6",
       "licenseId": "OLDAP-2.6",
       "seeAlso": [
@@ -3253,7 +4139,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.7.json",
-      "referenceNumber": "260",
+      "referenceNumber": "245",
       "name": "Open LDAP Public License v2.7",
       "licenseId": "OLDAP-2.7",
       "seeAlso": [
@@ -3265,19 +4151,19 @@
       "reference": "./OLDAP-2.8.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OLDAP-2.8.json",
-      "referenceNumber": "261",
+      "referenceNumber": "269",
       "name": "Open LDAP Public License v2.8",
       "licenseId": "OLDAP-2.8",
       "seeAlso": [
         "http://www.openldap.org/software/release/license.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./OML.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OML.json",
-      "referenceNumber": "262",
+      "referenceNumber": "180",
       "name": "Open Market License",
       "licenseId": "OML",
       "seeAlso": [
@@ -3286,23 +4172,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./OpenSSL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
-      "referenceNumber": "263",
-      "name": "OpenSSL License",
-      "licenseId": "OpenSSL",
-      "seeAlso": [
-        "http://www.openssl.org/source/license.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./OPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OPL-1.0.json",
-      "referenceNumber": "264",
+      "referenceNumber": "367",
       "name": "Open Public License v1.0",
       "licenseId": "OPL-1.0",
       "seeAlso": [
@@ -3315,12 +4188,12 @@
       "reference": "./OSET-PL-2.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/OSET-PL-2.1.json",
-      "referenceNumber": "265",
+      "referenceNumber": "219",
       "name": "OSET Public License version 2.1",
       "licenseId": "OSET-PL-2.1",
       "seeAlso": [
         "http://www.osetfoundation.org/public-license",
-        "http://opensource.org/licenses/OPL-2.1"
+        "https://opensource.org/licenses/OPL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3329,11 +4202,11 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.0.json",
-      "referenceNumber": "266",
+      "referenceNumber": "96",
       "name": "Open Software License 1.0",
       "licenseId": "OSL-1.0",
       "seeAlso": [
-        "http://opensource.org/licenses/OSL-1.0"
+        "https://opensource.org/licenses/OSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3342,7 +4215,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-1.1.json",
-      "referenceNumber": "267",
+      "referenceNumber": "186",
       "name": "Open Software License 1.1",
       "licenseId": "OSL-1.1",
       "seeAlso": [
@@ -3355,7 +4228,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.0.json",
-      "referenceNumber": "268",
+      "referenceNumber": "395",
       "name": "Open Software License 2.0",
       "licenseId": "OSL-2.0",
       "seeAlso": [
@@ -3368,12 +4241,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-2.1.json",
-      "referenceNumber": "269",
+      "referenceNumber": "163",
       "name": "Open Software License 2.1",
       "licenseId": "OSL-2.1",
       "seeAlso": [
         "http://web.archive.org/web/20050212003940/http://www.rosenlaw.com/osl21.htm",
-        "http://opensource.org/licenses/OSL-2.1"
+        "https://opensource.org/licenses/OSL-2.1"
       ],
       "isOsiApproved": true
     },
@@ -3382,24 +4255,38 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/OSL-3.0.json",
-      "referenceNumber": "270",
+      "referenceNumber": "153",
       "name": "Open Software License 3.0",
       "licenseId": "OSL-3.0",
       "seeAlso": [
-        "http://www.rosenlaw.com/OSL3.0.htm",
-        "http://www.opensource.org/licenses/OSL-3.0"
+        "https://web.archive.org/web/20120101081418/http://rosenlaw.com:80/OSL3.0.htm",
+        "https://opensource.org/licenses/OSL-3.0"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./OpenSSL.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/OpenSSL.json",
+      "referenceNumber": "86",
+      "name": "OpenSSL License",
+      "licenseId": "OpenSSL",
+      "seeAlso": [
+        "http://www.openssl.org/source/license.html"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./PDDL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PDDL-1.0.json",
-      "referenceNumber": "271",
-      "name": "ODC Public Domain Dedication & License 1.0",
+      "referenceNumber": "135",
+      "name": "Open Data Commons Public Domain Dedication & License 1.0",
       "licenseId": "PDDL-1.0",
       "seeAlso": [
-        "http://opendatacommons.org/licenses/pddl/1.0/"
+        "http://opendatacommons.org/licenses/pddl/1.0/",
+        "https://opendatacommons.org/licenses/pddl/"
       ],
       "isOsiApproved": false
     },
@@ -3407,12 +4294,12 @@
       "reference": "./PHP-3.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.0.json",
-      "referenceNumber": "272",
+      "referenceNumber": "208",
       "name": "PHP License v3.0",
       "licenseId": "PHP-3.0",
       "seeAlso": [
         "http://www.php.net/license/3_0.txt",
-        "http://www.opensource.org/licenses/PHP-3.0"
+        "https://opensource.org/licenses/PHP-3.0"
       ],
       "isOsiApproved": true
     },
@@ -3421,11 +4308,47 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/PHP-3.01.json",
-      "referenceNumber": "273",
+      "referenceNumber": "9",
       "name": "PHP License v3.01",
       "licenseId": "PHP-3.01",
       "seeAlso": [
         "http://www.php.net/license/3_01.txt"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./PSF-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PSF-2.0.json",
+      "referenceNumber": "93",
+      "name": "Python Software Foundation License 2.0",
+      "licenseId": "PSF-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Parity-6.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Parity-6.0.0.json",
+      "referenceNumber": "439",
+      "name": "The Parity Public License 6.0.0",
+      "licenseId": "Parity-6.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/6.0.0.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Parity-7.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Parity-7.0.0.json",
+      "referenceNumber": "426",
+      "name": "The Parity Public License 7.0.0",
+      "licenseId": "Parity-7.0.0",
+      "seeAlso": [
+        "https://paritylicense.com/versions/7.0.0.html"
       ],
       "isOsiApproved": false
     },
@@ -3433,7 +4356,7 @@
       "reference": "./Plexus.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Plexus.json",
-      "referenceNumber": "274",
+      "referenceNumber": "166",
       "name": "Plexus Classworlds License",
       "licenseId": "Plexus",
       "seeAlso": [
@@ -3442,52 +4365,66 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./PolyForm-Noncommercial-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PolyForm-Noncommercial-1.0.0.json",
+      "referenceNumber": "302",
+      "name": "PolyForm Noncommercial License 1.0.0",
+      "licenseId": "PolyForm-Noncommercial-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/noncommercial/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./PolyForm-Small-Business-1.0.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/PolyForm-Small-Business-1.0.0.json",
+      "referenceNumber": "120",
+      "name": "PolyForm Small Business License 1.0.0",
+      "licenseId": "PolyForm-Small-Business-1.0.0",
+      "seeAlso": [
+        "https://polyformproject.org/licenses/small-business/1.0.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
       "reference": "./PostgreSQL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/PostgreSQL.json",
-      "referenceNumber": "275",
+      "referenceNumber": "10",
       "name": "PostgreSQL License",
       "licenseId": "PostgreSQL",
       "seeAlso": [
         "http://www.postgresql.org/about/licence",
-        "http://www.opensource.org/licenses/PostgreSQL"
+        "https://opensource.org/licenses/PostgreSQL"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./psfrag.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
-      "referenceNumber": "276",
-      "name": "psfrag License",
-      "licenseId": "psfrag",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psfrag"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./psutils.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/psutils.json",
-      "referenceNumber": "277",
-      "name": "psutils License",
-      "licenseId": "psutils",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/psutils"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./Python-2.0.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Python-2.0.json",
-      "referenceNumber": "278",
+      "referenceNumber": "425",
       "name": "Python License 2.0",
       "licenseId": "Python-2.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Python-2.0"
+        "https://opensource.org/licenses/Python-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./QPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
+      "referenceNumber": "312",
+      "name": "Q Public License 1.0",
+      "licenseId": "QPL-1.0",
+      "seeAlso": [
+        "http://doc.qt.nokia.com/3.3/license.html",
+        "https://opensource.org/licenses/QPL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3495,7 +4432,7 @@
       "reference": "./Qhull.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Qhull.json",
-      "referenceNumber": "279",
+      "referenceNumber": "131",
       "name": "Qhull License",
       "licenseId": "Qhull",
       "seeAlso": [
@@ -3504,36 +4441,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./QPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/QPL-1.0.json",
-      "referenceNumber": "280",
-      "name": "Q Public License 1.0",
-      "licenseId": "QPL-1.0",
-      "seeAlso": [
-        "http://doc.qt.nokia.com/3.3/license.html",
-        "http://www.opensource.org/licenses/QPL-1.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Rdisc.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
-      "referenceNumber": "281",
-      "name": "Rdisc License",
-      "licenseId": "Rdisc",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./RHeCos-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RHeCos-1.1.json",
-      "referenceNumber": "282",
+      "referenceNumber": "60",
       "name": "Red Hat eCos Public License v1.1",
       "licenseId": "RHeCos-1.1",
       "seeAlso": [
@@ -3545,11 +4456,11 @@
       "reference": "./RPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.1.json",
-      "referenceNumber": "283",
+      "referenceNumber": "229",
       "name": "Reciprocal Public License 1.1",
       "licenseId": "RPL-1.1",
       "seeAlso": [
-        "http://opensource.org/licenses/RPL-1.1"
+        "https://opensource.org/licenses/RPL-1.1"
       ],
       "isOsiApproved": true
     },
@@ -3557,11 +4468,11 @@
       "reference": "./RPL-1.5.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RPL-1.5.json",
-      "referenceNumber": "284",
+      "referenceNumber": "107",
       "name": "Reciprocal Public License 1.5",
       "licenseId": "RPL-1.5",
       "seeAlso": [
-        "http://www.opensource.org/licenses/RPL-1.5"
+        "https://opensource.org/licenses/RPL-1.5"
       ],
       "isOsiApproved": true
     },
@@ -3570,12 +4481,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/RPSL-1.0.json",
-      "referenceNumber": "285",
+      "referenceNumber": "56",
       "name": "RealNetworks Public Source License v1.0",
       "licenseId": "RPSL-1.0",
       "seeAlso": [
         "https://helixcommunity.org/content/rpsl",
-        "http://www.opensource.org/licenses/RPSL-1.0"
+        "https://opensource.org/licenses/RPSL-1.0"
       ],
       "isOsiApproved": true
     },
@@ -3583,8 +4494,8 @@
       "reference": "./RSA-MD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSA-MD.json",
-      "referenceNumber": "286",
-      "name": "RSA Message-Digest License ",
+      "referenceNumber": "298",
+      "name": "RSA Message-Digest License",
       "licenseId": "RSA-MD",
       "seeAlso": [
         "http://www.faqs.org/rfcs/rfc1321.html"
@@ -3595,21 +4506,33 @@
       "reference": "./RSCPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/RSCPL.json",
-      "referenceNumber": "287",
+      "referenceNumber": "368",
       "name": "Ricoh Source Code Public License",
       "licenseId": "RSCPL",
       "seeAlso": [
         "http://wayback.archive.org/web/20060715140826/http://www.risource.org/RPL/RPL-1.0A.shtml",
-        "http://www.opensource.org/licenses/RSCPL"
+        "https://opensource.org/licenses/RSCPL"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./Rdisc.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Rdisc.json",
+      "referenceNumber": "354",
+      "name": "Rdisc License",
+      "licenseId": "Rdisc",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Rdisc_License"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./Ruby.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Ruby.json",
-      "referenceNumber": "288",
+      "referenceNumber": "51",
       "name": "Ruby License",
       "licenseId": "Ruby",
       "seeAlso": [
@@ -3621,7 +4544,7 @@
       "reference": "./SAX-PD.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SAX-PD.json",
-      "referenceNumber": "289",
+      "referenceNumber": "157",
       "name": "Sax Public Domain Notice",
       "licenseId": "SAX-PD",
       "seeAlso": [
@@ -3630,22 +4553,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Saxpath.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
-      "referenceNumber": "290",
-      "name": "Saxpath License",
-      "licenseId": "Saxpath",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./SCEA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SCEA.json",
-      "referenceNumber": "291",
+      "referenceNumber": "140",
       "name": "SCEA Shared Source License",
       "licenseId": "SCEA",
       "seeAlso": [
@@ -3654,23 +4565,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Sendmail.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
-      "referenceNumber": "292",
-      "name": "Sendmail License",
-      "licenseId": "Sendmail",
-      "seeAlso": [
-        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
-        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./SGI-B-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.0.json",
-      "referenceNumber": "293",
+      "referenceNumber": "203",
       "name": "SGI Free Software License B v1.0",
       "licenseId": "SGI-B-1.0",
       "seeAlso": [
@@ -3682,7 +4580,7 @@
       "reference": "./SGI-B-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-1.1.json",
-      "referenceNumber": "294",
+      "referenceNumber": "311",
       "name": "SGI Free Software License B v1.1",
       "licenseId": "SGI-B-1.1",
       "seeAlso": [
@@ -3695,7 +4593,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SGI-B-2.0.json",
-      "referenceNumber": "295",
+      "referenceNumber": "24",
       "name": "SGI Free Software License B v2.0",
       "licenseId": "SGI-B-2.0",
       "seeAlso": [
@@ -3704,26 +4602,26 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./SimPL-2.0.html",
+      "reference": "./SHL-0.5.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
-      "referenceNumber": "296",
-      "name": "Simple Public License 2.0",
-      "licenseId": "SimPL-2.0",
+      "detailsUrl": "http://spdx.org/licenses/SHL-0.5.json",
+      "referenceNumber": "47",
+      "name": "Solderpad Hardware License v0.5",
+      "licenseId": "SHL-0.5",
       "seeAlso": [
-        "http://www.opensource.org/licenses/SimPL-2.0"
+        "https://solderpad.org/licenses/SHL-0.5/"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
-      "reference": "./SISSL-1.2.html",
+      "reference": "./SHL-0.51.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
-      "referenceNumber": "297",
-      "name": "Sun Industry Standards Source License v1.2",
-      "licenseId": "SISSL-1.2",
+      "detailsUrl": "http://spdx.org/licenses/SHL-0.51.json",
+      "referenceNumber": "304",
+      "name": "Solderpad Hardware License, Version 0.51",
+      "licenseId": "SHL-0.51",
       "seeAlso": [
-        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
+        "https://solderpad.org/licenses/SHL-0.51/"
       ],
       "isOsiApproved": false
     },
@@ -3732,34 +4630,33 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SISSL.json",
-      "referenceNumber": "298",
+      "referenceNumber": "79",
       "name": "Sun Industry Standards Source License v1.1",
       "licenseId": "SISSL",
       "seeAlso": [
         "http://www.openoffice.org/licenses/sissl_license.html",
-        "http://opensource.org/licenses/SISSL"
+        "https://opensource.org/licenses/SISSL"
       ],
       "isOsiApproved": true
     },
     {
-      "reference": "./Sleepycat.html",
+      "reference": "./SISSL-1.2.html",
       "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
-      "referenceNumber": "299",
-      "name": "Sleepycat License",
-      "licenseId": "Sleepycat",
+      "detailsUrl": "http://spdx.org/licenses/SISSL-1.2.json",
+      "referenceNumber": "61",
+      "name": "Sun Industry Standards Source License v1.2",
+      "licenseId": "SISSL-1.2",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Sleepycat"
+        "http://gridscheduler.sourceforge.net/Gridengine_SISSL_license.html"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./SMLNJ.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/SMLNJ.json",
-      "referenceNumber": "300",
+      "referenceNumber": "232",
       "name": "Standard ML of New Jersey License",
       "licenseId": "SMLNJ",
       "seeAlso": [
@@ -3771,7 +4668,7 @@
       "reference": "./SMPPL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SMPPL.json",
-      "referenceNumber": "301",
+      "referenceNumber": "108",
       "name": "Secure Messaging Protocol Public License",
       "licenseId": "SMPPL",
       "seeAlso": [
@@ -3783,7 +4680,7 @@
       "reference": "./SNIA.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SNIA.json",
-      "referenceNumber": "302",
+      "referenceNumber": "328",
       "name": "SNIA Public License 1.1",
       "licenseId": "SNIA",
       "seeAlso": [
@@ -3792,10 +4689,136 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./SPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
+      "referenceNumber": "264",
+      "name": "Sun Public License v1.0",
+      "licenseId": "SPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SPL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./SSH-OpenSSH.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SSH-OpenSSH.json",
+      "referenceNumber": "19",
+      "name": "SSH OpenSSH license",
+      "licenseId": "SSH-OpenSSH",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/LICENCE#L10"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SSH-short.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SSH-short.json",
+      "referenceNumber": "68",
+      "name": "SSH short notice",
+      "licenseId": "SSH-short",
+      "seeAlso": [
+        "https://github.com/openssh/openssh-portable/blob/1b11ea7c58cd5c59838b5fa574cd456d6047b2d4/pathnames.h",
+        "http://web.mit.edu/kolya/.f/root/athena.mit.edu/sipb.mit.edu/project/openssh/OldFiles/src/openssh-2.9.9p2/ssh-add.1",
+        "https://joinup.ec.europa.eu/svn/lesoll/trunk/italc/lib/src/dsa_key.cpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SSPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SSPL-1.0.json",
+      "referenceNumber": "371",
+      "name": "Server Side Public License, v 1",
+      "licenseId": "SSPL-1.0",
+      "seeAlso": [
+        "https://www.mongodb.com/licensing/server-side-public-license"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SWL.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SWL.json",
+      "referenceNumber": "94",
+      "name": "Scheme Widget Library (SWL) Software License Agreement",
+      "licenseId": "SWL",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/SWL"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Saxpath.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Saxpath.json",
+      "referenceNumber": "27",
+      "name": "Saxpath License",
+      "licenseId": "Saxpath",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Saxpath_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Sendmail.json",
+      "referenceNumber": "320",
+      "name": "Sendmail License",
+      "licenseId": "Sendmail",
+      "seeAlso": [
+        "http://www.sendmail.com/pdfs/open_source/sendmail_license.pdf",
+        "https://web.archive.org/web/20160322142305/https://www.sendmail.com/pdfs/open_source/sendmail_license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Sendmail-8.23.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Sendmail-8.23.json",
+      "referenceNumber": "184",
+      "name": "Sendmail License 8.23",
+      "licenseId": "Sendmail-8.23",
+      "seeAlso": [
+        "https://www.proofpoint.com/sites/default/files/sendmail-license.pdf",
+        "https://web.archive.org/web/20181003101040/https://www.proofpoint.com/sites/default/files/sendmail-license.pdf"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./SimPL-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/SimPL-2.0.json",
+      "referenceNumber": "275",
+      "name": "Simple Public License 2.0",
+      "licenseId": "SimPL-2.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/SimPL-2.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Sleepycat.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Sleepycat.json",
+      "referenceNumber": "58",
+      "name": "Sleepycat License",
+      "licenseId": "Sleepycat",
+      "seeAlso": [
+        "https://opensource.org/licenses/Sleepycat"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./Spencer-86.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-86.json",
-      "referenceNumber": "303",
+      "referenceNumber": "195",
       "name": "Spencer License 86",
       "licenseId": "Spencer-86",
       "seeAlso": [
@@ -3807,7 +4830,7 @@
       "reference": "./Spencer-94.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-94.json",
-      "referenceNumber": "304",
+      "referenceNumber": "227",
       "name": "Spencer License 94",
       "licenseId": "Spencer-94",
       "seeAlso": [
@@ -3819,7 +4842,7 @@
       "reference": "./Spencer-99.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Spencer-99.json",
-      "referenceNumber": "305",
+      "referenceNumber": "65",
       "name": "Spencer License 99",
       "licenseId": "Spencer-99",
       "seeAlso": [
@@ -3828,23 +4851,22 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./SPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/SPL-1.0.json",
-      "referenceNumber": "306",
-      "name": "Sun Public License v1.0",
-      "licenseId": "SPL-1.0",
+      "reference": "./StandardML-NJ.html",
+      "isDeprecatedLicenseId": true,
+      "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
+      "referenceNumber": "310",
+      "name": "Standard ML of New Jersey License",
+      "licenseId": "StandardML-NJ",
       "seeAlso": [
-        "http://www.opensource.org/licenses/SPL-1.0"
+        "http://www.smlnj.org//license.html"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./SugarCRM-1.1.3.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/SugarCRM-1.1.3.json",
-      "referenceNumber": "307",
+      "referenceNumber": "375",
       "name": "SugarCRM Public License v1.1.3",
       "licenseId": "SugarCRM-1.1.3",
       "seeAlso": [
@@ -3853,14 +4875,14 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./SWL.html",
+      "reference": "./TAPR-OHL-1.0.html",
       "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/SWL.json",
-      "referenceNumber": "308",
-      "name": "Scheme Widget Library (SWL) Software License Agreement",
-      "licenseId": "SWL",
+      "detailsUrl": "http://spdx.org/licenses/TAPR-OHL-1.0.json",
+      "referenceNumber": "2",
+      "name": "TAPR Open Hardware License v1.0",
+      "licenseId": "TAPR-OHL-1.0",
       "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/SWL"
+        "https://www.tapr.org/OHL"
       ],
       "isOsiApproved": false
     },
@@ -3868,7 +4890,7 @@
       "reference": "./TCL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCL.json",
-      "referenceNumber": "309",
+      "referenceNumber": "53",
       "name": "TCL/TK License",
       "licenseId": "TCL",
       "seeAlso": [
@@ -3881,7 +4903,7 @@
       "reference": "./TCP-wrappers.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TCP-wrappers.json",
-      "referenceNumber": "310",
+      "referenceNumber": "257",
       "name": "TCP Wrappers License",
       "licenseId": "TCP-wrappers",
       "seeAlso": [
@@ -3893,7 +4915,7 @@
       "reference": "./TMate.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TMate.json",
-      "referenceNumber": "311",
+      "referenceNumber": "436",
       "name": "TMate Open Source License",
       "licenseId": "TMate",
       "seeAlso": [
@@ -3905,7 +4927,7 @@
       "reference": "./TORQUE-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TORQUE-1.1.json",
-      "referenceNumber": "312",
+      "referenceNumber": "201",
       "name": "TORQUE v2.5+ Software License v1.1",
       "licenseId": "TORQUE-1.1",
       "seeAlso": [
@@ -3917,7 +4939,7 @@
       "reference": "./TOSL.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/TOSL.json",
-      "referenceNumber": "313",
+      "referenceNumber": "268",
       "name": "Trusster Open Source License",
       "licenseId": "TOSL",
       "seeAlso": [
@@ -3926,10 +4948,59 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./TU-Berlin-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-1.0.json",
+      "referenceNumber": "403",
+      "name": "Technische Universitaet Berlin License 1.0",
+      "licenseId": "TU-Berlin-1.0",
+      "seeAlso": [
+        "https://github.com/swh/ladspa/blob/7bf6f3799fdba70fda297c2d8fd9f526803d9680/gsm/COPYRIGHT"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./TU-Berlin-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/TU-Berlin-2.0.json",
+      "referenceNumber": "424",
+      "name": "Technische Universitaet Berlin License 2.0",
+      "licenseId": "TU-Berlin-2.0",
+      "seeAlso": [
+        "https://github.com/CorsixTH/deps/blob/fd339a9f526d1d9c9f01ccf39e438a015da50035/licences/libgsm.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./UCL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/UCL-1.0.json",
+      "referenceNumber": "313",
+      "name": "Upstream Compatibility License v1.0",
+      "licenseId": "UCL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UCL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./UPL-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
+      "referenceNumber": "147",
+      "name": "Universal Permissive License v1.0",
+      "licenseId": "UPL-1.0",
+      "seeAlso": [
+        "https://opensource.org/licenses/UPL"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./Unicode-DFS-2015.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2015.json",
-      "referenceNumber": "314",
+      "referenceNumber": "279",
       "name": "Unicode License Agreement - Data Files and Software (2015)",
       "licenseId": "Unicode-DFS-2015",
       "seeAlso": [
@@ -3941,19 +5012,19 @@
       "reference": "./Unicode-DFS-2016.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-DFS-2016.json",
-      "referenceNumber": "315",
+      "referenceNumber": "401",
       "name": "Unicode License Agreement - Data Files and Software (2016)",
       "licenseId": "Unicode-DFS-2016",
       "seeAlso": [
         "http://www.unicode.org/copyright.html"
       ],
-      "isOsiApproved": false
+      "isOsiApproved": true
     },
     {
       "reference": "./Unicode-TOU.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Unicode-TOU.json",
-      "referenceNumber": "316",
+      "referenceNumber": "15",
       "name": "Unicode Terms of Use",
       "licenseId": "Unicode-TOU",
       "seeAlso": [
@@ -3966,45 +5037,19 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/Unlicense.json",
-      "referenceNumber": "317",
+      "referenceNumber": "183",
       "name": "The Unlicense",
       "licenseId": "Unlicense",
       "seeAlso": [
-        "http://unlicense.org/"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./UPL-1.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/UPL-1.0.json",
-      "referenceNumber": "318",
-      "name": "Universal Permissive License v1.0",
-      "licenseId": "UPL-1.0",
-      "seeAlso": [
-        "http://opensource.org/licenses/UPL"
+        "https://unlicense.org/"
       ],
       "isOsiApproved": true
-    },
-    {
-      "reference": "./Vim.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Vim.json",
-      "referenceNumber": "319",
-      "name": "Vim License",
-      "licenseId": "Vim",
-      "seeAlso": [
-        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
-      ],
-      "isOsiApproved": false
     },
     {
       "reference": "./VOSTROM.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VOSTROM.json",
-      "referenceNumber": "320",
+      "referenceNumber": "382",
       "name": "VOSTROM Public License for Open Source",
       "licenseId": "VOSTROM",
       "seeAlso": [
@@ -4016,11 +5061,38 @@
       "reference": "./VSL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/VSL-1.0.json",
-      "referenceNumber": "321",
+      "referenceNumber": "422",
       "name": "Vovida Software License v1.0",
       "licenseId": "VSL-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/VSL-1.0"
+        "https://opensource.org/licenses/VSL-1.0"
+      ],
+      "isOsiApproved": true
+    },
+    {
+      "reference": "./Vim.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Vim.json",
+      "referenceNumber": "223",
+      "name": "Vim License",
+      "licenseId": "Vim",
+      "seeAlso": [
+        "http://vimdoc.sourceforge.net/htmldoc/uganda.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./W3C.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/W3C.json",
+      "referenceNumber": "109",
+      "name": "W3C Software Notice and License (2002-12-31)",
+      "licenseId": "W3C",
+      "seeAlso": [
+        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
+        "https://opensource.org/licenses/W3C"
       ],
       "isOsiApproved": true
     },
@@ -4028,7 +5100,7 @@
       "reference": "./W3C-19980720.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-19980720.json",
-      "referenceNumber": "322",
+      "referenceNumber": "284",
       "name": "W3C Software Notice and License (1998-07-20)",
       "licenseId": "W3C-19980720",
       "seeAlso": [
@@ -4040,7 +5112,7 @@
       "reference": "./W3C-20150513.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/W3C-20150513.json",
-      "referenceNumber": "323",
+      "referenceNumber": "113",
       "name": "W3C Software Notice and Document License (2015-05-13)",
       "licenseId": "W3C-20150513",
       "seeAlso": [
@@ -4049,28 +5121,28 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./W3C.html",
+      "reference": "./WTFPL.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/W3C.json",
-      "referenceNumber": "324",
-      "name": "W3C Software Notice and License (2002-12-31)",
-      "licenseId": "W3C",
+      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
+      "referenceNumber": "17",
+      "name": "Do What The F*ck You Want To Public License",
+      "licenseId": "WTFPL",
       "seeAlso": [
-        "http://www.w3.org/Consortium/Legal/2002/copyright-software-20021231.html",
-        "http://www.opensource.org/licenses/W3C"
+        "http://www.wtfpl.net/about/",
+        "http://sam.zoy.org/wtfpl/COPYING"
       ],
-      "isOsiApproved": true
+      "isOsiApproved": false
     },
     {
       "reference": "./Watcom-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Watcom-1.0.json",
-      "referenceNumber": "325",
+      "referenceNumber": "327",
       "name": "Sybase Open Watcom Public License 1.0",
       "licenseId": "Watcom-1.0",
       "seeAlso": [
-        "http://www.opensource.org/licenses/Watcom-1.0"
+        "https://opensource.org/licenses/Watcom-1.0"
       ],
       "isOsiApproved": true
     },
@@ -4078,7 +5150,7 @@
       "reference": "./Wsuipa.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/Wsuipa.json",
-      "referenceNumber": "326",
+      "referenceNumber": "293",
       "name": "Wsuipa License",
       "licenseId": "Wsuipa",
       "seeAlso": [
@@ -4087,24 +5159,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./WTFPL.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/WTFPL.json",
-      "referenceNumber": "327",
-      "name": "Do What The F*ck You Want To Public License",
-      "licenseId": "WTFPL",
-      "seeAlso": [
-        "http://sam.zoy.org/wtfpl/COPYING"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./X11.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/X11.json",
-      "referenceNumber": "328",
+      "referenceNumber": "102",
       "name": "X11 License",
       "licenseId": "X11",
       "seeAlso": [
@@ -4113,23 +5172,11 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Xerox.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
-      "referenceNumber": "329",
-      "name": "Xerox License",
-      "licenseId": "Xerox",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xerox"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./XFree86-1.1.html",
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/XFree86-1.1.json",
-      "referenceNumber": "330",
+      "referenceNumber": "160",
       "name": "XFree86 License 1.1",
       "licenseId": "XFree86-1.1",
       "seeAlso": [
@@ -4138,47 +5185,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./xinetd.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
-      "referenceNumber": "331",
-      "name": "xinetd License",
-      "licenseId": "xinetd",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Xnet.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
-      "referenceNumber": "332",
-      "name": "X.Net License",
-      "licenseId": "Xnet",
-      "seeAlso": [
-        "http://opensource.org/licenses/Xnet"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./xpp.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/xpp.json",
-      "referenceNumber": "333",
-      "name": "XPP License",
-      "licenseId": "xpp",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/xpp"
-      ],
-      "isOsiApproved": false
-    },
-    {
       "reference": "./XSkat.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/XSkat.json",
-      "referenceNumber": "334",
+      "referenceNumber": "82",
       "name": "XSkat License",
       "licenseId": "XSkat",
       "seeAlso": [
@@ -4187,10 +5197,34 @@
       "isOsiApproved": false
     },
     {
+      "reference": "./Xerox.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xerox.json",
+      "referenceNumber": "239",
+      "name": "Xerox License",
+      "licenseId": "Xerox",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xerox"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Xnet.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Xnet.json",
+      "referenceNumber": "340",
+      "name": "X.Net License",
+      "licenseId": "Xnet",
+      "seeAlso": [
+        "https://opensource.org/licenses/Xnet"
+      ],
+      "isOsiApproved": true
+    },
+    {
       "reference": "./YPL-1.0.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.0.json",
-      "referenceNumber": "335",
+      "referenceNumber": "314",
       "name": "Yahoo! Public License v1.0",
       "licenseId": "YPL-1.0",
       "seeAlso": [
@@ -4203,7 +5237,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/YPL-1.1.json",
-      "referenceNumber": "336",
+      "referenceNumber": "39",
       "name": "Yahoo! Public License v1.1",
       "licenseId": "YPL-1.1",
       "seeAlso": [
@@ -4212,86 +5246,10 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./Zed.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zed.json",
-      "referenceNumber": "337",
-      "name": "Zed License",
-      "licenseId": "Zed",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Zed"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zend-2.0.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
-      "referenceNumber": "338",
-      "name": "Zend License v2.0",
-      "licenseId": "Zend-2.0",
-      "seeAlso": [
-        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.3.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
-      "referenceNumber": "339",
-      "name": "Zimbra Public License v1.3",
-      "licenseId": "Zimbra-1.3",
-      "seeAlso": [
-        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zimbra-1.4.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
-      "referenceNumber": "340",
-      "name": "Zimbra Public License v1.4",
-      "licenseId": "Zimbra-1.4",
-      "seeAlso": [
-        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./zlib-acknowledgement.html",
-      "isDeprecatedLicenseId": false,
-      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
-      "referenceNumber": "341",
-      "name": "zlib/libpng License with Acknowledgement",
-      "licenseId": "zlib-acknowledgement",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./Zlib.html",
-      "isDeprecatedLicenseId": false,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
-      "referenceNumber": "342",
-      "name": "zlib License",
-      "licenseId": "Zlib",
-      "seeAlso": [
-        "http://www.zlib.net/zlib_license.html",
-        "http://www.opensource.org/licenses/Zlib"
-      ],
-      "isOsiApproved": true
-    },
-    {
       "reference": "./ZPL-1.1.html",
       "isDeprecatedLicenseId": false,
       "detailsUrl": "http://spdx.org/licenses/ZPL-1.1.json",
-      "referenceNumber": "343",
+      "referenceNumber": "87",
       "name": "Zope Public License 1.1",
       "licenseId": "ZPL-1.1",
       "seeAlso": [
@@ -4304,12 +5262,12 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.0.json",
-      "referenceNumber": "344",
+      "referenceNumber": "115",
       "name": "Zope Public License 2.0",
       "licenseId": "ZPL-2.0",
       "seeAlso": [
         "http://old.zope.org/Resources/License/ZPL-2.0",
-        "http://opensource.org/licenses/ZPL-2.0"
+        "https://opensource.org/licenses/ZPL-2.0"
       ],
       "isOsiApproved": true
     },
@@ -4318,7 +5276,7 @@
       "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/ZPL-2.1.json",
-      "referenceNumber": "345",
+      "referenceNumber": "399",
       "name": "Zope Public License 2.1",
       "licenseId": "ZPL-2.1",
       "seeAlso": [
@@ -4327,351 +5285,313 @@
       "isOsiApproved": false
     },
     {
-      "reference": "./AGPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-1.0.json",
-      "referenceNumber": "346",
-      "name": "Affero General Public License v1.0",
-      "licenseId": "AGPL-1.0",
+      "reference": "./Zed.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zed.json",
+      "referenceNumber": "116",
+      "name": "Zed License",
+      "licenseId": "Zed",
       "seeAlso": [
-        "http://www.affero.org/oagpl.html"
+        "https://fedoraproject.org/wiki/Licensing/Zed"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./AGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
+      "reference": "./Zend-2.0.html",
+      "isDeprecatedLicenseId": false,
       "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/AGPL-3.0.json",
-      "referenceNumber": "347",
-      "name": "GNU Affero General Public License v3.0",
-      "licenseId": "AGPL-3.0",
+      "detailsUrl": "http://spdx.org/licenses/Zend-2.0.json",
+      "referenceNumber": "405",
+      "name": "Zend License v2.0",
+      "licenseId": "Zend-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/agpl.txt",
-        "http://www.opensource.org/licenses/AGPL-3.0"
+        "https://web.archive.org/web/20130517195954/http://www.zend.com/license/2_00.txt"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.3.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.3.json",
+      "referenceNumber": "185",
+      "name": "Zimbra Public License v1.3",
+      "licenseId": "Zimbra-1.3",
+      "seeAlso": [
+        "http://web.archive.org/web/20100302225219/http://www.zimbra.com/license/zimbra-public-license-1-3.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zimbra-1.4.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/Zimbra-1.4.json",
+      "referenceNumber": "416",
+      "name": "Zimbra Public License v1.4",
+      "licenseId": "Zimbra-1.4",
+      "seeAlso": [
+        "http://www.zimbra.com/legal/zimbra-public-license-1-4"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./Zlib.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/Zlib.json",
+      "referenceNumber": "40",
+      "name": "zlib License",
+      "licenseId": "Zlib",
+      "seeAlso": [
+        "http://www.zlib.net/zlib_license.html",
+        "https://opensource.org/licenses/Zlib"
       ],
       "isOsiApproved": true
+    },
+    {
+      "reference": "./blessing.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/blessing.json",
+      "referenceNumber": "450",
+      "name": "SQLite Blessing",
+      "licenseId": "blessing",
+      "seeAlso": [
+        "https://www.sqlite.org/src/artifact/e33a4df7e32d742a?ln=4-9",
+        "https://sqlite.org/src/artifact/df5091916dbb40e6"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./bzip2-1.0.5.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.5.json",
+      "referenceNumber": "199",
+      "name": "bzip2 and libbzip2 License v1.0.5",
+      "licenseId": "bzip2-1.0.5",
+      "seeAlso": [
+        "https://sourceware.org/bzip2/1.0.5/bzip2-manual-1.0.5.html",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./bzip2-1.0.6.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/bzip2-1.0.6.json",
+      "referenceNumber": "74",
+      "name": "bzip2 and libbzip2 License v1.0.6",
+      "licenseId": "bzip2-1.0.6",
+      "seeAlso": [
+        "https://sourceware.org/git/?p=bzip2.git;a=blob;f=LICENSE;hb=bzip2-1.0.6",
+        "http://bzip.org/1.0.5/bzip2-manual-1.0.5.html"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./copyleft-next-0.3.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.0.json",
+      "referenceNumber": "339",
+      "name": "copyleft-next 0.3.0",
+      "licenseId": "copyleft-next-0.3.0",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.0"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./copyleft-next-0.3.1.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/copyleft-next-0.3.1.json",
+      "referenceNumber": "409",
+      "name": "copyleft-next 0.3.1",
+      "licenseId": "copyleft-next-0.3.1",
+      "seeAlso": [
+        "https://github.com/copyleft-next/copyleft-next/blob/master/Releases/copyleft-next-0.3.1"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./curl.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/curl.json",
+      "referenceNumber": "341",
+      "name": "curl License",
+      "licenseId": "curl",
+      "seeAlso": [
+        "https://github.com/bagder/curl/blob/master/COPYING"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./diffmark.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/diffmark.json",
+      "referenceNumber": "430",
+      "name": "diffmark license",
+      "licenseId": "diffmark",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/diffmark"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./dvipdfm.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/dvipdfm.json",
+      "referenceNumber": "14",
+      "name": "dvipdfm License",
+      "licenseId": "dvipdfm",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/dvipdfm"
+      ],
+      "isOsiApproved": false
     },
     {
       "reference": "./eCos-2.0.html",
       "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
       "detailsUrl": "http://spdx.org/licenses/eCos-2.0.json",
-      "referenceNumber": "348",
+      "referenceNumber": "292",
       "name": "eCos license version 2.0",
       "licenseId": "eCos-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/ecos-license.html"
+        "https://www.gnu.org/licenses/ecos-license.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.1.json",
-      "referenceNumber": "349",
-      "name": "GNU Free Documentation License v1.1",
-      "licenseId": "GFDL-1.1",
+      "reference": "./eGenix.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/eGenix.json",
+      "referenceNumber": "228",
+      "name": "eGenix.com Public License 1.1.0",
+      "licenseId": "eGenix",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.1.txt"
+        "http://www.egenix.com/products/eGenix.com-Public-License-1.1.0.pdf",
+        "https://fedoraproject.org/wiki/Licensing/eGenix.com_Public_License_1.1.0"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.2.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.2.json",
-      "referenceNumber": "350",
-      "name": "GNU Free Documentation License v1.2",
-      "licenseId": "GFDL-1.2",
+      "reference": "./etalab-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/etalab-2.0.json",
+      "referenceNumber": "278",
+      "name": "Etalab Open License 2.0",
+      "licenseId": "etalab-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/fdl-1.2.txt"
+        "https://github.com/DISIC/politique-de-contribution-open-source/blob/master/LICENSE.pdf",
+        "https://raw.githubusercontent.com/DISIC/politique-de-contribution-open-source/master/LICENSE"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GFDL-1.3.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GFDL-1.3.json",
-      "referenceNumber": "351",
-      "name": "GNU Free Documentation License v1.3",
-      "licenseId": "GFDL-1.3",
+      "reference": "./gSOAP-1.3b.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/gSOAP-1.3b.json",
+      "referenceNumber": "235",
+      "name": "gSOAP Public License v1.3b",
+      "licenseId": "gSOAP-1.3b",
       "seeAlso": [
-        "http://www.gnu.org/licenses/fdl-1.3.txt"
+        "http://www.cs.fsu.edu/~engelen/license.html"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-1.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0+.json",
-      "referenceNumber": "352",
-      "name": "GNU General Public License v1.0 or later",
-      "licenseId": "GPL-1.0+",
+      "reference": "./gnuplot.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/gnuplot.json",
+      "referenceNumber": "414",
+      "name": "gnuplot License",
+      "licenseId": "gnuplot",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "https://fedoraproject.org/wiki/Licensing/Gnuplot"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-1.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-1.0.json",
-      "referenceNumber": "353",
-      "name": "GNU General Public License v1.0 only",
-      "licenseId": "GPL-1.0",
+      "reference": "./iMatix.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/iMatix.json",
+      "referenceNumber": "198",
+      "name": "iMatix Standard Function Library Agreement",
+      "licenseId": "iMatix",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-1.0-standalone.html"
+        "http://legacy.imatix.com/html/sfl/sfl4.htm#license"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0+.json",
-      "referenceNumber": "354",
-      "name": "GNU General Public License v2.0 or later",
-      "licenseId": "GPL-2.0+",
+      "reference": "./libpng-2.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libpng-2.0.json",
+      "referenceNumber": "110",
+      "name": "PNG Reference Library version 2",
+      "licenseId": "libpng-2.0",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-2.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-autoconf-exception.json",
-      "referenceNumber": "355",
-      "name": "GNU General Public License v2.0 w/Autoconf exception",
-      "licenseId": "GPL-2.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://ac-archive.sourceforge.net/doc/copyright.html"
+        "http://www.libpng.org/pub/png/src/libpng-LICENSE.txt"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0-with-bison-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-bison-exception.json",
-      "referenceNumber": "356",
-      "name": "GNU General Public License v2.0 w/Bison exception",
-      "licenseId": "GPL-2.0-with-bison-exception",
+      "reference": "./libselinux-1.0.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libselinux-1.0.json",
+      "referenceNumber": "12",
+      "name": "libselinux public domain notice",
+      "licenseId": "libselinux-1.0",
       "seeAlso": [
-        "http://git.savannah.gnu.org/cgit/bison.git/tree/data/yacc.c?id=193d7c7054ba7197b0789e14965b739162319b5e#n141"
+        "https://github.com/SELinuxProject/selinux/blob/master/libselinux/LICENSE"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0-with-classpath-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-classpath-exception.json",
-      "referenceNumber": "357",
-      "name": "GNU General Public License v2.0 w/Classpath exception",
-      "licenseId": "GPL-2.0-with-classpath-exception",
+      "reference": "./libtiff.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/libtiff.json",
+      "referenceNumber": "440",
+      "name": "libtiff License",
+      "licenseId": "libtiff",
       "seeAlso": [
-        "http://www.gnu.org/software/classpath/license.html"
+        "https://fedoraproject.org/wiki/Licensing/libtiff"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0-with-font-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-font-exception.json",
-      "referenceNumber": "358",
-      "name": "GNU General Public License v2.0 w/Font exception",
-      "licenseId": "GPL-2.0-with-font-exception",
+      "reference": "./mpich2.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/mpich2.json",
+      "referenceNumber": "69",
+      "name": "mpich2 License",
+      "licenseId": "mpich2",
       "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-faq.html#FontException"
+        "https://fedoraproject.org/wiki/Licensing/MIT"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0-with-GCC-exception.json",
-      "referenceNumber": "359",
-      "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-2.0-with-GCC-exception",
+      "reference": "./psfrag.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psfrag.json",
+      "referenceNumber": "441",
+      "name": "psfrag License",
+      "licenseId": "psfrag",
       "seeAlso": [
-        "https://gcc.gnu.org/git/?p=gcc.git;a=blob;f=gcc/libgcc1.c;h=762f5143fc6eed57b6797c82710f3538aa52b40b;hb=cb143a3ce4fb417c68f5fa2691a1b1b1053dfba9#l10"
+        "https://fedoraproject.org/wiki/Licensing/psfrag"
       ],
       "isOsiApproved": false
     },
     {
-      "reference": "./GPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-2.0.json",
-      "referenceNumber": "360",
-      "name": "GNU General Public License v2.0 only",
-      "licenseId": "GPL-2.0",
+      "reference": "./psutils.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/psutils.json",
+      "referenceNumber": "296",
+      "name": "psutils License",
+      "licenseId": "psutils",
       "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/gpl-2.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-2.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0+.json",
-      "referenceNumber": "361",
-      "name": "GNU General Public License v3.0 or later",
-      "licenseId": "GPL-3.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0-with-autoconf-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-autoconf-exception.json",
-      "referenceNumber": "362",
-      "name": "GNU General Public License v3.0 w/Autoconf exception",
-      "licenseId": "GPL-3.0-with-autoconf-exception",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/autoconf-exception-3.0.html"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./GPL-3.0-with-GCC-exception.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0-with-GCC-exception.json",
-      "referenceNumber": "363",
-      "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
-      "licenseId": "GPL-3.0-with-GCC-exception",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gcc-exception-3.1.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./GPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/GPL-3.0.json",
-      "referenceNumber": "364",
-      "name": "GNU General Public License v3.0 only",
-      "licenseId": "GPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/gpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/GPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0+.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0+.json",
-      "referenceNumber": "365",
-      "name": "GNU Library General Public License v2 or later",
-      "licenseId": "LGPL-2.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.0.html",
-      "isDeprecatedLicenseId": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.0.json",
-      "referenceNumber": "366",
-      "name": "GNU Library General Public License v2 only",
-      "licenseId": "LGPL-2.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.0-standalone.html"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1+.json",
-      "referenceNumber": "367",
-      "name": "GNU Library General Public License v2.1 or later",
-      "licenseId": "LGPL-2.1+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-2.1.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-2.1.json",
-      "referenceNumber": "368",
-      "name": "GNU Lesser General Public License v2.1 only",
-      "licenseId": "LGPL-2.1",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/old-licenses/lgpl-2.1-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-2.1"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0+.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0+.json",
-      "referenceNumber": "369",
-      "name": "GNU Lesser General Public License v3.0 or later",
-      "licenseId": "LGPL-3.0+",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./LGPL-3.0.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/LGPL-3.0.json",
-      "referenceNumber": "370",
-      "name": "GNU Lesser General Public License v3.0 only",
-      "licenseId": "LGPL-3.0",
-      "seeAlso": [
-        "http://www.gnu.org/licenses/lgpl-3.0-standalone.html",
-        "http://www.opensource.org/licenses/LGPL-3.0"
-      ],
-      "isOsiApproved": true
-    },
-    {
-      "reference": "./Nunit.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/Nunit.json",
-      "referenceNumber": "371",
-      "name": "Nunit License",
-      "licenseId": "Nunit",
-      "seeAlso": [
-        "https://fedoraproject.org/wiki/Licensing/Nunit"
-      ],
-      "isOsiApproved": false
-    },
-    {
-      "reference": "./StandardML-NJ.html",
-      "isDeprecatedLicenseId": true,
-      "isFsfLibre": true,
-      "detailsUrl": "http://spdx.org/licenses/StandardML-NJ.json",
-      "referenceNumber": "372",
-      "name": "Standard ML of New Jersey License",
-      "licenseId": "StandardML-NJ",
-      "seeAlso": [
-        "http://www.smlnj.org//license.html"
+        "https://fedoraproject.org/wiki/Licensing/psutils"
       ],
       "isOsiApproved": false
     },
@@ -4679,14 +5599,51 @@
       "reference": "./wxWindows.html",
       "isDeprecatedLicenseId": true,
       "detailsUrl": "http://spdx.org/licenses/wxWindows.json",
-      "referenceNumber": "373",
+      "referenceNumber": "260",
       "name": "wxWindows Library License",
       "licenseId": "wxWindows",
       "seeAlso": [
-        "http://www.opensource.org/licenses/WXwindows"
+        "https://opensource.org/licenses/WXwindows"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xinetd.html",
+      "isDeprecatedLicenseId": false,
+      "isFsfLibre": true,
+      "detailsUrl": "http://spdx.org/licenses/xinetd.json",
+      "referenceNumber": "432",
+      "name": "xinetd License",
+      "licenseId": "xinetd",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/Xinetd_License"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./xpp.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/xpp.json",
+      "referenceNumber": "97",
+      "name": "XPP License",
+      "licenseId": "xpp",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/xpp"
+      ],
+      "isOsiApproved": false
+    },
+    {
+      "reference": "./zlib-acknowledgement.html",
+      "isDeprecatedLicenseId": false,
+      "detailsUrl": "http://spdx.org/licenses/zlib-acknowledgement.json",
+      "referenceNumber": "262",
+      "name": "zlib/libpng License with Acknowledgement",
+      "licenseId": "zlib-acknowledgement",
+      "seeAlso": [
+        "https://fedoraproject.org/wiki/Licensing/ZlibWithAcknowledgement"
       ],
       "isOsiApproved": false
     }
   ],
-  "releaseDate": "2018-04-14"
+  "releaseDate": "2021-02-14"
 }


### PR DESCRIPTION
Hi :wave: 

We’d love to use your gem [spdx-license](https://rubygems.org/gems/spdx-licenses) in our project, but licenses list seems to be outdated.

Here is a PR to favor last version 3.11 of licenses data from
https://github.com/spdx/license-list-data/commit/6820cab01008b520a72289bbdc6b2a895afc2590

Bests,